### PR TITLE
Enqueue the plugin's own stylesheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- Accessible default styles for focus states on buttons & links in the cookie panel
+
 ## [0.1.0] - 2020-11-13
 
 - Initial release

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,1 +1,78 @@
 /* default plugin styles */
+#ccc #ccc-icon.ccc-icon--no-outline:focus {
+    outline: 3px solid #171919;
+}
+
+#ccc #ccc-icon.ccc-icon--no-outline:hover #triangle path {
+    fill: #171919;
+}
+
+#ccc #ccc-icon.ccc-icon--no-outline:focus #triangle path {
+    fill: #fd0;
+}
+
+#ccc #ccc-icon.ccc-icon--no-outline:focus #star path {
+    fill: #171919;
+}
+
+#ccc .ccc-notify-button:focus,
+#ccc .ccc-content--dark .ccc-button-solid:focus {
+    background-color: #171919;
+    border-color: #fd0 !important;
+    outline: 3px solid transparent;
+    -webkit-box-shadow: inset 0 0 0 1px #fd0;
+    box-shadow: inset 0 0 0 1px #fd0;
+    color: #fff;
+}
+
+#ccc .ccc-notify-button:hover,
+#ccc .ccc-content--dark .ccc-button-solid:hover {
+    background-color: #171919;
+}
+
+#ccc .ccc-content--light .ccc-notify-button:hover {
+    background-color: #333;
+}
+
+#ccc .ccc-content--light .ccc-notify-button:hover span,
+#ccc .ccc-content--light .ccc-notify-button:focus span,
+#ccc .ccc-content--dark .ccc-notify-button:hover span,
+#ccc .ccc-content--dark .ccc-notify-button:focus span,
+#ccc .ccc-content--dark .ccc-button-solid:focus span,
+#ccc .ccc-content--dark .ccc-button-solid:hover span {
+    color: #fff;
+    background-color: transparent;
+}
+
+#ccc .checkbox-toggle--dark .checkbox-toggle-toggle,
+#ccc .checkbox-toggle--light .checkbox-toggle-toggle {
+    background-color: #fff !important;
+}
+
+#ccc .checkbox-toggle--slider:focus-within {
+    background-color: #171919;;
+    border-color: #fd0 !important;
+    outline: 3px solid transparent;
+    -webkit-box-shadow: inset 0 0 0 1px #fd0;
+    box-shadow: inset 0 0 0 1px #fd0;
+}
+
+#ccc .checkbox-toggle--slider .checkbox-toggle-on,
+#ccc .checkbox-toggle--slider .checkbox-toggle-off {
+    opacity: 1 !important;
+    color: #fff !important;
+}
+
+.ccc-link:focus,
+#ccc a:focus {
+    outline: 3px solid transparent;
+    color: #0b0c0c !important;;
+    background-color: #fd0;
+    -webkit-box-shadow: 0 -2px #fd0,0 4px #0b0c0c;
+    box-shadow: 0 -2px #fd0,0 4px #0b0c0c;
+    text-decoration: none;
+}
+
+#ccc a:focus svg path {
+    fill: #0b0c0c;
+}

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,1 @@
+/* default plugin styles */

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -14,7 +14,9 @@ describe(Scripts::class, function () {
     describe('->register()', function () {
         it('adds actions', function () {
             allow('add_action')->toBeCalled();
-            expect('add_action')->toBeCalled()->with('wp_enqueue_scripts', [$this->scripts, 'enqueueScripts'])->once();
+            expect('add_action')->toBeCalled()->times(2);
+            expect('add_action')->toBeCalled()->with('wp_enqueue_scripts', [$this->scripts, 'enqueueScripts']);
+            expect('add_action')->toBeCalled()->with('wp_enqueue_scripts', [$this->scripts, 'enqueueStyles']);
             $this->scripts->register();
         });
     });
@@ -57,6 +59,17 @@ describe(Scripts::class, function () {
                     $this->scripts->enqueueScripts();
                 });
             });
+        });
+    });
+
+    describe('->enqueueStyles()', function () {
+        it('enqueues the plugin stylesheet', function () {
+            allow('dirname')->toBeCalled()->andReturn('/path/to/this/plugin');
+            allow('plugins_url')->toBeCalled()->andReturn('http://path/to/this/plugin/assets/css/styles.css');
+            expect('plugins_url')->toBeCalled()->once()->with('/assets/css/styles.css', '/path/to/this/plugin');
+            allow('wp_enqueue_style')->toBeCalled();
+            expect('wp_enqueue_style')->toBeCalled()->once()->with('analytics-with-consent-styles', 'http://path/to/this/plugin/assets/css/styles.css');
+            $this->scripts->enqueueStyles();
         });
     });
 });

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -7,6 +7,7 @@ class Scripts implements \Dxw\Iguana\Registerable
     public function register() : void
     {
         add_action('wp_enqueue_scripts', [$this, 'enqueueScripts']);
+        add_action('wp_enqueue_scripts', [$this, 'enqueueStyles']);
     }
 
     public function enqueueScripts() : void
@@ -23,5 +24,10 @@ class Scripts implements \Dxw\Iguana\Registerable
                 'googleAnalyticsId' => $googleAnalyticsId
             ]);
         }
+    }
+
+    public function enqueueStyles() : void
+    {
+        wp_enqueue_style('analytics-with-consent-styles', plugins_url('/assets/css/styles.css', dirname(__FILE__)));
     }
 }


### PR DESCRIPTION
This adds a default stylesheet to the plugin that applies some styles that civic cookie's own stylesheet doesn't - mainly accessibility fixes on focus state for buttons & links in the cookie panel.

e.g.
Before (no focus styles applied on focus):
<img width="180" alt="Screenshot 2021-02-26 at 16 23 31" src="https://user-images.githubusercontent.com/370665/109326371-01084200-784f-11eb-821b-1c76adfdd7b1.png">


After (with focus styles applied):
<img width="190" alt="Screenshot 2021-02-26 at 16 22 39" src="https://user-images.githubusercontent.com/370665/109326265-dcac6580-784e-11eb-9b33-e7acf34255c8.png">
