### PR TITLE
Fix/amend CSS override issues

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -115,13 +115,8 @@
     line-height: inherit !important;
 }
 
-#ccc-title, .ccc-title {
-    font-size: 1rem !important;
-    line-height: 1.5 !important;
-}
-
 #ccc h3.optional-cookie-header {
-    padding: .5rem 0 1rem 3.8rem;
+    padding: .5rem 0 1rem 55px;
 }
 
 @media screen and (max-width:768px) {


### PR DESCRIPTION
In this PR:

- Fix to remove `rem` font size on headings - some sites the headings were inheriting a much smaller size
- Fix to overlapping header over pixel-based size custom appearance checkbox