### PR TITLE
Feature/14067 customise cookie consent

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -34,6 +34,20 @@
     background-color: #333;
 }
 
+#ccc-dismiss-button {
+    background-color: transparent !important;
+}
+
+#ccc-dismiss-button span {
+    font-weight: 400 !important;
+    color: #fff !important;
+    background-color: transparent !important;
+}
+
+#ccc-dismiss-button:hover {
+    background-color: #171919 !important;
+}
+
 #ccc .ccc-content--light .ccc-notify-button:hover span,
 #ccc .ccc-content--light .ccc-notify-button:focus span,
 #ccc .ccc-content--dark .ccc-notify-button:hover span,

--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -6,9 +6,12 @@ var config = {
   closeStyle: 'button',
   initialState: 'open',
   text: {
-    closeLabel: 'Save and Close',
-    acceptSettings: 'Accept all cookies',
-    rejectSettings: 'Only accept necessary cookies'
+    title: cookieControlConfig.title,
+    intro: cookieControlConfig.intro,
+    necessaryDescription: cookieControlConfig.necessaryDescription,
+    closeLabel: cookieControlConfig.closeLabel,
+    acceptSettings: cookieControlConfig.acceptSettings,
+    rejectSettings: cookieControlConfig.rejectSettings
   },
   branding: {
     removeAbout: true
@@ -21,7 +24,7 @@ var config = {
     {
       name: 'analytics',
       label: 'Analytical Cookies',
-      description: 'Analytical cookies help us to improve our website by collecting and reporting information on its usage.',
+      description: cookieControlConfig.analyticalDescription,
       cookies: ['_ga', '_gid', '_gat', '__utma', '__utmt', '__utmb', '__utmc', '__utmz', '__utmv'],
       onAccept: function () {
         // Add Google Analytics

--- a/src/Options.php
+++ b/src/Options.php
@@ -4,6 +4,24 @@ namespace AnalyticsWithConsent;
 
 class Options implements \Dxw\Iguana\Registerable
 {
+    private $defaults;
+
+    function __construct() {
+        $this->defaults = [
+            'title' => 'This site uses cookies to store information on your computer.',
+            'intro' => 'Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.',
+            'necessaryDescription' => 'Necessary cookies enable core functionality such as page navigation and access to secure areas. The website cannot function properly without these cookies, and can only be disabled by changing your browser preferences.',
+            'analyticalDescription' => 'Analytical cookies help us to improve our website by collecting and reporting information on its usage.',
+            'closeLabel' => 'Save and Close',
+            'acceptSettings' => 'Accept all cookies',
+            'rejectSettings' => 'Only accept necessary cookies'
+        ];
+    }
+
+    public function getDefault($key) {
+        return $this->defaults[$key] ?? null;
+    }
+
     public function register() : void
     {
         add_action('acf/init', [$this, 'acfInit']);
@@ -19,7 +37,7 @@ class Options implements \Dxw\Iguana\Registerable
 
         acf_add_local_field_group([
             'key' => 'group_5f986aaed3444',
-            'title' => 'Analytics with Consent',
+            'title' => 'Analytics with Consent: Main settings',
             'fields' => [
                 [
                     'key' => 'field_5f986ab76a819',
@@ -104,5 +122,164 @@ class Options implements \Dxw\Iguana\Registerable
             'active' => 1,
             'description' => '',
         ]);
+
+        acf_add_local_field_group([
+            'key' => 'group_5f986aaed3445',
+            'title' => 'Analytics with Consent: Customisation',
+            'fields' => [
+                [
+                    'key' => 'field_5f986ab76a820',
+                    'label' => 'Title',
+                    'name' => 'civic_cookie_control_title',
+                    'type' => 'text',
+                    'instructions' => '',
+                    'required' => 0,
+                    'conditional_logic' => 0,
+                    'wrapper' => [
+                        'width' => '',
+                        'class' => '',
+                        'id' => '',
+                    ],
+                    'default_value' => $this->getDefault('title'),
+                    'placeholder' => '',
+                    'prepend' => '',
+                    'append' => '',
+                    'maxlength' => '',
+                ],
+                [
+                    'key' => 'field_5f986ab76a822',
+                    'label' => 'Intro',
+                    'name' => 'civic_cookie_control_intro',
+                    'type' => 'textarea',
+                    'instructions' => '',
+                    'required' => 0,
+                    'conditional_logic' => 0,
+                    'wrapper' => [
+                        'width' => '',
+                        'class' => '',
+                        'id' => '',
+                    ],
+                    'default_value' => $this->getDefault('intro'),
+                    'placeholder' => '',
+                    'prepend' => '',
+                    'append' => '',
+                    'maxlength' => '',
+                ],
+                [
+                    'key' => 'field_5f986ab76a824',
+                    'label' => 'Necessary cookies decription',
+                    'name' => 'civic_cookie_control_necessaryDescription',
+                    'type' => 'textarea',
+                    'instructions' => '',
+                    'required' => 0,
+                    'conditional_logic' => 0,
+                    'wrapper' => [
+                        'width' => '',
+                        'class' => '',
+                        'id' => '',
+                    ],
+                    'default_value' => $this->getDefault('necessaryDescription'),
+                    'placeholder' => '',
+                    'prepend' => '',
+                    'append' => '',
+                    'maxlength' => '',
+                ],
+                [
+                    'key' => 'field_5f986ab76a826',
+                    'label' => 'Analytical cookies description',
+                    'name' => 'civic_cookie_control_analyticalDescription',
+                    'type' => 'textarea',
+                    'instructions' => '',
+                    'required' => 0,
+                    'conditional_logic' => 0,
+                    'wrapper' => [
+                        'width' => '',
+                        'class' => '',
+                        'id' => '',
+                    ],
+                    'default_value' => $this->getDefault('analyticalDescription'),
+                    'placeholder' => '',
+                    'prepend' => '',
+                    'append' => '',
+                    'maxlength' => '',
+                ],
+                [
+                    'key' => 'field_5f986ab76a828',
+                    'label' => 'Close button text',
+                    'name' => 'civic_cookie_control_closeLabel',
+                    'type' => 'text',
+                    'instructions' => '',
+                    'required' => 0,
+                    'conditional_logic' => 0,
+                    'wrapper' => [
+                        'width' => '',
+                        'class' => '',
+                        'id' => '',
+                    ],
+                    'default_value' => $this->getDefault('closeLabel'),
+                    'placeholder' => '',
+                    'prepend' => '',
+                    'append' => '',
+                    'maxlength' => '',
+                ],
+                [
+                    'key' => 'field_5f986ab76a830',
+                    'label' => 'Accept all button text',
+                    'name' => 'civic_cookie_control_acceptSettings',
+                    'type' => 'text',
+                    'instructions' => '',
+                    'required' => 0,
+                    'conditional_logic' => 0,
+                    'wrapper' => [
+                        'width' => '',
+                        'class' => '',
+                        'id' => '',
+                    ],
+                    'default_value' => $this->getDefault('acceptSettings'),
+                    'placeholder' => '',
+                    'prepend' => '',
+                    'append' => '',
+                    'maxlength' => '',
+                ],
+                [
+                    'key' => 'field_5f986ab76a832',
+                    'label' => 'Accept only necessary cookies button text',
+                    'name' => 'civic_cookie_control_rejectSettings',
+                    'type' => 'text',
+                    'instructions' => '',
+                    'required' => 0,
+                    'conditional_logic' => 0,
+                    'wrapper' => [
+                        'width' => '',
+                        'class' => '',
+                        'id' => '',
+                    ],
+                    'default_value' => $this->getDefault('rejectSettings'),
+                    'placeholder' => '',
+                    'prepend' => '',
+                    'append' => '',
+                    'maxlength' => '',
+                ],
+            ],
+            'location' => [
+                [
+                    [
+                        'param' => 'options_page',
+                        'operator' => '==',
+                        'value' => 'analytics-with-consent',
+                    ],
+                ],
+            ],
+            'menu_order' => 1,
+            'position' => 'normal',
+            'style' => 'default',
+            'label_placement' => 'top',
+            'instruction_placement' => 'label',
+            'hide_on_screen' => '',
+            'active' => 1,
+            'description' => '',
+        ]);
+
     }
 }
+

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -15,13 +15,32 @@ class Scripts implements \Dxw\Iguana\Registerable
         $apiKey = get_field('civic_cookie_control_api_key', 'option');
         $productType = get_field('civic_cookie_control_product_type', 'option');
         $googleAnalyticsId = get_field('google_analytics_id', 'option');
+
         if ($apiKey && $productType) {
+            // resolve customisation options to saved value or default
+            $options = new \AnalyticsWithConsent\Options;
+            $title = get_field('civic_cookie_control_title', 'option') ?? $options->getDefault('title');
+            $intro = get_field('civic_cookie_control_intro', 'option') ?? $options->getDefault('intro');
+            $necessaryDescription = get_field('civic_cookie_control_necessaryDescription', 'option') ?? $options->getDefault('necessaryDescription');
+            $analyticalDescription = get_field('civic_cookie_control_analyticalDescription', 'option') ?? $options->getDefault('analyticalDescription');
+            $closeLabel = get_field('civic_cookie_control_closeLabel', 'option') ?? $options->getDefault('closeLabel');
+            $acceptSettings = get_field('civic_cookie_control_acceptSettings', 'option') ?? $options->getDefault('acceptSettings');
+            $rejectSettings = get_field('civic_cookie_control_rejectSettings', 'option') ?? $options->getDefault('rejectSettings');
+
+            // enqueue scripts with options
             wp_enqueue_script('civicCookieControl', 'https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js');
             wp_enqueue_script('civicCookieControlConfig', plugins_url('/assets/js/config.js', dirname(__FILE__)), ['civicCookieControl']);
             wp_localize_script('civicCookieControlConfig', 'cookieControlConfig', [
                 'apiKey' => $apiKey,
                 'productType' => $productType,
-                'googleAnalyticsId' => $googleAnalyticsId
+                'googleAnalyticsId' => $googleAnalyticsId,
+                'title' => $title,
+                'intro' => $intro,
+                'necessaryDescription' => $necessaryDescription,
+                'analyticalDescription' => $analyticalDescription,
+                'closeLabel' => $closeLabel,
+                'acceptSettings' => $acceptSettings,
+                'rejectSettings' => $rejectSettings
             ]);
         }
     }


### PR DESCRIPTION
Add customisations to cookie consent plugin. Includes:

- Make description texts and button labels customisable via WP options with defaults
- Make dismiss ("Save and close") button only equally prominent as other buttons, to avoid leading users to accept the default limited cookie setting.

 - Resolves: https://dxw.zendesk.com/agent/tickets/13745 and https://dxw.zendesk.com/agent/tickets/14067 (in part)
