### PR TITLE
Feature/make modular

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `awc_civic_cookie_control_config` filter, to allow default config to be added to or over-ridden
+
 ## [0.2.2] - 2021-04-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ With [Whippet](https://github.com/dxw/whippet):
 
 * Follow the instructions in the [Whippet documentation](https://github.com/dxw/whippet/blob/main/docs/themesandplugins.md)
 
-Without Whippet:
+Without Whippet (not recommended):
 
 * Copy this repo into your `wp-content/plugins/` folder.
 
@@ -24,3 +24,36 @@ This plugin does not currently support Google Analytics 4.
 Activate the plugin, and add the relevant info the to the plugin's settings page under Settings > Analytics with Consent.
 
 On a multisite, this will need to be done on a per-subsite basis.
+
+## Customisation
+
+You can use the `awc_civic_cookie_control_config` filter to add to or over-ride the default Civic Cookie Control config this plugin provides.
+
+e.g. if you wanted to change the panel position from left to right, in your plugin or theme:
+
+```
+add_filter('awc_civic_cookie_control_config', function ($config) {
+    $config['position'] = 'RIGHT';
+    return $config;
+});
+```
+
+If you're adding config that requires JavaScript function calls (e.g. the "onAccept" and "onRevoke" parameters for specific cookie types), you can pass the name of any function that is in the global namespace. e.g. 
+
+```
+add_filter('awc_civic_cookie_control_config', function ($config) {
+    $config['optionalCookies'][0]['onAccept] = 'doThis'; \\this will call the doThis() function in the global namespace
+    return $config;
+});
+```
+
+You can also do the same with namespaced functions (as long as the top-level object is in the global namespace). e.g.
+
+```
+add_filter('awc_civic_cookie_control_config', function ($config) {
+    $config['optionalCookies'][0]['onAccept] = 'myNamespace.doThis'; \\this will call the myNamespace.doThis() function
+    return $config;
+});
+```
+
+Note that you can't pass JavaScript closures directly.

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -1,0 +1,23 @@
+/* globals cookieControlDefaultAnalytics */
+/* eslint-disable */
+var analyticsWithConsent = {
+  gaAccept: function () {
+    // Add Google Analytics   
+    (function (i, s, o, g, r, a, m) {
+      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date(); a = s.createElement(o),
+      m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga')
+  
+    ga('create', cookieControlDefaultAnalytics.googleAnalyticsId, 'auto')
+    ga('send', 'pageview')
+    // End Google Analytics   
+  },
+  gaRevoke: function () {
+    // Disable Google Analytics
+    window['ga-disable-' + cookieControlDefaultAnalytics.googleAnalyticsId] = true
+    // End Google Analytics
+  }
+}
+/* eslint-enable */

--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -1,50 +1,24 @@
-/* globals cookieControlConfig, ga, CookieControl */
+/* globals cookieControlConfig, CookieControl */
 
-var config = {
-  apiKey: cookieControlConfig.apiKey,
-  product: cookieControlConfig.productType,
-  closeStyle: 'button',
-  initialState: 'open',
-  text: {
-    closeLabel: 'Save and Close',
-    acceptSettings: 'Accept all cookies',
-    rejectSettings: 'Only accept necessary cookies'
-  },
-  branding: {
-    removeAbout: true
-  },
-  position: 'LEFT',
-  theme: 'DARK',
-  subDomains: false,
-  toggleType: 'checkbox',
-  optionalCookies: [
-    {
-      name: 'analytics',
-      label: 'Analytical Cookies',
-      description: 'Analytical cookies help us to improve our website by collecting and reporting information on its usage.',
-      cookies: ['_ga', '_gid', '_gat', '__utma', '__utmt', '__utmb', '__utmc', '__utmz', '__utmv'],
-      onAccept: function () {
-        // Add Google Analytics
-        /* eslint-disable */
-        (function (i, s, o, g, r, a, m) {
-          i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-            (i[r].q = i[r].q || []).push(arguments)
-          }, i[r].l = 1 * new Date(); a = s.createElement(o),
-          m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-        })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga')
+window.getFunctionFromString = function (string) {
+  var scope = window
+  var scopeSplit = string.split('.')
+  for (var i = 0; i < scopeSplit.length - 1; i++) {
+    scope = scope[scopeSplit[i]]
 
-        ga('create', cookieControlConfig.googleAnalyticsId, 'auto')
-        ga('send', 'pageview')
-        // End Google Analytics
-        /* eslint-enable */
-      },
-      onRevoke: function () {
-        // Disable Google Analytics
-        window['ga-disable-' + cookieControlConfig.googleAnalyticsId] = true
-        // End Google Analytics
-      }
-    }
-  ]
+    if (scope === undefined) return
+  }
+
+  return scope[scopeSplit[scopeSplit.length - 1]]
 }
 
-CookieControl.load(config)
+cookieControlConfig.optionalCookies.forEach(function (optionalCookie) {
+  if (optionalCookie.onAccept) {
+    optionalCookie.onAccept = window.getFunctionFromString(optionalCookie.onAccept)
+  }
+  if (optionalCookie.onRevoke) {
+    optionalCookie.onRevoke = window.getFunctionFromString(optionalCookie.onRevoke)
+  }
+})
+
+CookieControl.load(cookieControlConfig)

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -41,21 +41,22 @@ describe(Scripts::class, function () {
             context('and Civic Product Type is set', function () {
                 it('enqueues the Civic Cookie Control script and the config script, and injects our settings', function () {
                     allow('get_field')->toBeCalled()->andReturn('an_api_key', 'a_product_type', 'a_ga_id');
-                    expect('get_field')->toBeCalled()->once()->with('civic_cookie_control_api_key', 'option');
-                    expect('get_field')->toBeCalled()->once()->with('civic_cookie_control_product_type', 'option');
+                    expect('get_field')->toBeCalled()->times(2)->with('civic_cookie_control_api_key', 'option');
+                    expect('get_field')->toBeCalled()->times(2)->with('civic_cookie_control_product_type', 'option');
                     expect('get_field')->toBeCalled()->once()->with('google_analytics_id', 'option');
                     allow('wp_enqueue_script')->toBeCalled();
                     expect('wp_enqueue_script')->toBeCalled()->once()->with('civicCookieControl', 'https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js');
                     allow('dirname')->toBeCalled()->andReturn('/path/to/this/plugin');
-                    allow('plugins_url')->toBeCalled()->andReturn('http://path/to/this/plugin/assets/js/config.js');
+                    allow('plugins_url')->toBeCalled()->andReturn('http://path/to/this/plugin/assets/js/analytics.js', 'http://path/to/this/plugin/assets/js/config.js');
+                    expect('plugins_url')->toBeCalled()->once()->with('/assets/js/analytics.js', '/path/to/this/plugin');
+                    expect('wp_enqueue_script')->toBeCalled()->once()->with('civicCookieControlDefaultAnalytics', 'http://path/to/this/plugin/assets/js/analytics.js', ['civicCookieControl']);
                     expect('plugins_url')->toBeCalled()->once()->with('/assets/js/config.js', '/path/to/this/plugin');
-                    expect('wp_enqueue_script')->toBeCalled()->once()->with('civicCookieControlConfig', 'http://path/to/this/plugin/assets/js/config.js', ['civicCookieControl']);
+                    expect('wp_enqueue_script')->toBeCalled()->once()->with('civicCookieControlConfig', 'http://path/to/this/plugin/assets/js/config.js', ['civicCookieControl', 'civicCookieControlDefaultAnalytics']);
                     allow('wp_localize_script')->toBeCalled();
-                    expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlConfig', 'cookieControlConfig', [
-                        'apiKey' => 'an_api_key',
-                        'productType' => 'a_product_type',
+                    expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlDefaultAnalytics', 'cookieControlDefaultAnalytics', [
                         'googleAnalyticsId' => 'a_ga_id'
                     ]);
+                    expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlConfig', 'cookieControlConfig', \Kahlan\Arg::toBeAn('array'));
                     $this->scripts->enqueueScripts();
                 });
             });

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -39,7 +39,7 @@ describe(Scripts::class, function () {
                 });
             });
             context('and Civic Product Type is set', function () {
-                it('enqueues the Civic Cookie Control script and the config script, and injects our settings', function () {
+                it('enqueues the Civic Cookie Control script and the config and analytics scripts, and injects our settings, with the option to filter them', function () {
                     allow('get_field')->toBeCalled()->andReturn('an_api_key', 'a_product_type', 'a_ga_id');
                     expect('get_field')->toBeCalled()->times(2)->with('civic_cookie_control_api_key', 'option');
                     expect('get_field')->toBeCalled()->times(2)->with('civic_cookie_control_product_type', 'option');
@@ -56,6 +56,10 @@ describe(Scripts::class, function () {
                     expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlDefaultAnalytics', 'cookieControlDefaultAnalytics', [
                         'googleAnalyticsId' => 'a_ga_id'
                     ]);
+                    allow('apply_filters')->toBeCalled()->andRun(function ($filterName, $filteredData) {
+                        return $filteredData;
+                    });
+                    expect('apply_filters')->toBeCalled()->once()->with('awc_civic_cookie_control_config', \Kahlan\Arg::toBeAn('array'));
                     expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlConfig', 'cookieControlConfig', \Kahlan\Arg::toBeAn('array'));
                     $this->scripts->enqueueScripts();
                 });

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -17,17 +17,49 @@ class Scripts implements \Dxw\Iguana\Registerable
         $googleAnalyticsId = get_field('google_analytics_id', 'option');
         if ($apiKey && $productType) {
             wp_enqueue_script('civicCookieControl', 'https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js');
-            wp_enqueue_script('civicCookieControlConfig', plugins_url('/assets/js/config.js', dirname(__FILE__)), ['civicCookieControl']);
-            wp_localize_script('civicCookieControlConfig', 'cookieControlConfig', [
-                'apiKey' => $apiKey,
-                'productType' => $productType,
+            wp_enqueue_script('civicCookieControlDefaultAnalytics', plugins_url('/assets/js/analytics.js', dirname(__FILE__)), ['civicCookieControl']);
+            wp_localize_script('civicCookieControlDefaultAnalytics', 'cookieControlDefaultAnalytics', [
                 'googleAnalyticsId' => $googleAnalyticsId
             ]);
+            wp_enqueue_script('civicCookieControlConfig', plugins_url('/assets/js/config.js', dirname(__FILE__)), ['civicCookieControl', 'civicCookieControlDefaultAnalytics']);
+            wp_localize_script('civicCookieControlConfig', 'cookieControlConfig', $this->defaultConfig());
         }
     }
 
     public function enqueueStyles() : void
     {
         wp_enqueue_style('analytics-with-consent-styles', plugins_url('/assets/css/styles.css', dirname(__FILE__)));
+    }
+
+    private function defaultConfig() : array
+    {
+        return [
+            'apiKey' => get_field('civic_cookie_control_api_key', 'option'),
+            'product' => get_field('civic_cookie_control_product_type', 'option'),
+            'closeStyle' => 'button',
+            'initialState' => 'open',
+            'text' => [
+                'closeLabel' => 'Save and Close',
+                'acceptSettings' => 'Accept all cookies',
+                'rejectSettings' => 'Only accept necessary cookies'
+            ],
+            'branding' => [
+                'removeAbout' => true
+            ],
+            'position' => 'LEFT',
+            'theme' => 'DARK',
+            'subDomains' => false,
+            'toggleType' => 'checkbox',
+            'optionalCookies' => [
+                [
+                    'name' => 'analytics',
+                    'label' => 'Analytical Cookies',
+                    'description' => 'Analytical cookies help us to improve our website by collecting and reporting information on its usage.',
+                    'cookies' => ['_ga', '_gid', '_gat', '__utma', '__utmt', '__utmb', '__utmc', '__utmz', '__utmv'],
+                    'onAccept' => "analyticsWithConsent.gaAccept",
+                    'onRevoke' => "analyticsWithConsent.gaRevoke"
+                ]
+            ]
+        ];
     }
 }

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -33,7 +33,7 @@ class Scripts implements \Dxw\Iguana\Registerable
 
     private function defaultConfig() : array
     {
-        return [
+        return apply_filters('awc_civic_cookie_control_config', [
             'apiKey' => get_field('civic_cookie_control_api_key', 'option'),
             'product' => get_field('civic_cookie_control_product_type', 'option'),
             'closeStyle' => 'button',
@@ -60,6 +60,6 @@ class Scripts implements \Dxw\Iguana\Registerable
                     'onRevoke' => "analyticsWithConsent.gaRevoke"
                 ]
             ]
-        ];
+        ]);
     }
 }


### PR DESCRIPTION
This PR gives the plugin a small API we can hook into, in order to customise it further if needed.

Before, most of the config was hardcoded into the JS, so if we wanted to e.g. change the positioning or button labels, there wasn't any way of doing that. Now, all the config is generated in the PHP, and has the `awc_civic_cookie_control_config` filter applied to it. That means that if we want to e.g. change the panel position from left to right, we can do that like this: 

```
add_filter('awc_civic_cookie_control_config', function ($config) {
    $config['position'] = 'RIGHT';
    return $config;
});
```

That means we can keep this base plugin, and extend and customise it either on a client-by-client basis (e.g. by adding code to their theme), or by creating additional plugins that have option pages where preferences can be set that are then applied using the `awc_civic_cookie_control_config` filter.

As well as changing styling preferences, this could also include e.g. adding additional cookie options for people to opt in and out of, or even replacing the default GA code with Google Analytics 4 code.

Using this approach means that this should remain a small, easily maintainable core plugin, and any additional plugins to provide further extension and customisation should also be fairly small and manageable. Then we can just develop and deploy those extra plugins as and when needed.