### PR TITLE
v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2021-05-25
+
 ### Added
 
 - `awc_civic_cookie_control_config` filter, to allow default config to be added to or over-ridden

--- a/index.php
+++ b/index.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://github.com/dxw/analytics-with-consent
  * Description: Google Analytics + CIVIC Cookie Control
  * Author: dxw
- * Version: 0.2.2
+ * Version: 1.0.0
  * Network: True
  */
 


### PR DESCRIPTION
Bump version to 1.0.0.

This plugin is widely in use across the sites we manage, and now we have an API in place for customising all the config, it seems an appropriate point to go to v1.0. 