### PR TITLE
Add Google Analytics event tracking

### DIFF
--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -14,9 +14,8 @@ var analyticsWithConsent = {
     ga('send', 'pageview')
     let trackEvents
     trackEvents = cookieControlDefaultAnalytics.track_events;
-    alert(trackEvents);
     // HACK
-    trackEvents = true;
+    // trackEvents = true;
     if (trackEvents) {
       window.analyticsWithConsent.gaAddEvents();
     }
@@ -28,15 +27,15 @@ var analyticsWithConsent = {
   },
   gaAddOutboundEvents: function() {    
 
-    // HACK get domain via JS (from civicCookieControlDefaultAnalytics-js src)
+    // HACK option get domain via JS (from civicCookieControlDefaultAnalytics-js src)
     // e.g. <script type='text/javascript' src='http://localhost/servicetransformation/wp-content/plugins/analytics-with-consent/assets/js/analytics.js?ver=5.7.2' id='civicCookieControlDefaultAnalytics-js'></script>
     function getSiteUrl() {
       let alink = document.getElementsByTagName('link')[0].href;
       let siteurl = alink.substr(0, alink.indexOf('/wp-content'));
       return siteurl;
     }
-    //let siteurl = cookieControlDefaultAnalytics.siteurl;
-    let siteurl = getSiteUrl();    
+    let siteurl = cookieControlDefaultAnalytics.siteurl;
+    //let siteurl = getSiteUrl();    
 
     // check links
     $('a[href]').each(function() {
@@ -58,8 +57,7 @@ var analyticsWithConsent = {
         }
       }
       // if outbound, add ga event
-      if (isOutbound) {
-        console.log(link);
+      if (isOutbound) {        
         this.onclick = function() {
           let label = fulllink;
           ga('send', 'event', 'outbound-link', fulllink, label, 0,

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -12,9 +12,11 @@ var analyticsWithConsent = {
   
     ga('create', cookieControlDefaultAnalytics.googleAnalyticsId, 'auto')
     ga('send', 'pageview')
-    //let trackEvents = cookieControlDefaultAnalytics.track_events;
+    let trackEvents
+    trackEvents = cookieControlDefaultAnalytics.track_events;
+    alert(trackEvents);
     // HACK
-    let trackEvents = true;
+    trackEvents = true;
     if (trackEvents) {
       window.analyticsWithConsent.gaAddEvents();
     }

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -36,8 +36,7 @@ var analyticsWithConsent = {
         target = this.getAttribute('target').toLowerCase();
       }
       if (link.indexOf('http') !== -1) {
-        let linkcontent = link.substring(link.indexOf('//')+2);
-        if (linkcontent.indexOf(cookieControlDefaultAnalytics.domain) !== 0) {
+        if (link.indexOf(cookieControlDefaultAnalytics.siteurl) !== 0) {
           isOutbound = true;
         }
       }

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -12,7 +12,128 @@ var analyticsWithConsent = {
   
     ga('create', cookieControlDefaultAnalytics.googleAnalyticsId, 'auto')
     ga('send', 'pageview')
+    if (cookieControlDefaultAnalytics.track_events) {
+      window.analyticsWithConsent.gaAddEvents();
+    }
     // End Google Analytics   
+  },
+  gaAddEvents: function() {
+    window.analyticsWithConsent.gaAddOutboundEvents();
+    window.analyticsWithConsent.gaAddDownloadEvents();
+  },
+  gaAddOutboundEvents: function() {
+    // check links
+    $('a[href]').each(function() {
+      // check if outbound (to another domain)
+      let isOutbound = false;
+      let fulllink = this.getAttribute('href');
+      let link = fulllink;
+      if (link.indexOf('?') !== -1) {
+        link = link.substr(0, link.indexOf('?'));
+      }
+      let target = '';
+      if (this.hasAttribute('target')) {
+        target = this.getAttribute('target').toLowerCase();
+      }
+      if (link.indexOf('http') !== -1) {
+        let linkcontent = link.substring(link.indexOf('//')+2);
+        if (linkcontent.indexOf(cookieControlDefaultAnalytics.domain) !== 0) {
+          isOutbound = true;
+        }
+      }
+      // if outbound, add ga event
+      if (isOutbound) {
+        this.onclick = function() {
+          let label = fulllink;
+          ga('send', 'event', 'outbound-link', fulllink, label, 0,
+            {
+              'nonInteration':false,
+              'transport': 'beacon',
+            });
+        }
+      }
+    });
+  },
+  gaAddDownloadEvents: function() {
+
+    var docs = [
+      'pdf','docx','doc','xlsx','xls','pptx','ppt','dot','dotx',
+      'odt','fodt','ods','fods','odp','fodp','odg','fodg','odf','ott',
+      'txt','epub','rtf','csv','xml',
+      'zip','rar',
+      'mp4','mp3','webm','wav','mpg','mpeg','wma','ogg','mid','midi','m3u','3gp','flv','mov',
+      'png','jpg','gif','jpeg','svg','bmp','tif','tiff','eps'
+    ];
+
+    // try determine if a document link in various ways:
+      // if a wp-content/uploads link
+      // not an #anchor link or url with trailing slash
+      // if extension matches a document type
+    function isDocumentLink(link) {
+      isDocument = false;
+      if (link.indexOf('wp-content/uploads') !== -1) {
+        isDocument = true;
+      }
+      let trailingSlash = link.substr(link.length-1) == '/';
+      let anchorLink = link.substr(0,1) == '#';
+      let extension = getExtension(link);
+      if (!trailingSlash && !anchorLink) {
+        for (let c = 0; c < docs.length; c++) {
+          if (extension == docs[c]) {
+            isDocument = true;
+            break;
+          }
+        }
+      }
+      return isDocument;
+    }
+
+    // try determine extension (assuming last 3 or 4 characters after '.')
+    function getExtension(link) {
+      let extension = '';
+      if (link.indexOf('.') !== -1) {
+        let parts = link.split('.');
+        if (parts.length > 0) {
+          let finalpart = parts[parts.length-1];
+          if (finalpart.length == 3 || finalpart.length == 4) {
+            extension = finalpart;
+          }
+        }
+      }
+      return extension.toLowerCase();
+    }
+
+    // check links
+    $('a[href]').each(function() {
+      let fulllink = this.getAttribute('href');
+      let link = fulllink;
+      if (link.indexOf('?') !== -1) {
+        link = link.substr(0, link.indexOf('?'));
+      }
+      let isDocument = isDocumentLink(link);
+      if (!isDocument) { return; }
+
+      // if a document link, add ga event
+      if (isDocument) {
+        let target = '';
+        if (this.hasAttribute('target')) {
+          target = this.getAttribute('target').toLowerCase();
+        }
+        let extension = getExtension(link);
+
+        this.onclick = function() {
+          let label = fulllink;
+          if (extension != '') {
+            label += ' (' + extension + ')';
+          }
+          ga('send', 'event','download', fulllink, label , 0,
+            {
+              'nonInteration':false,
+              'transport': 'beacon',
+            });
+        }
+      }
+    });
   },
   gaRevoke: function () {
     // Disable Google Analytics

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -12,16 +12,30 @@ var analyticsWithConsent = {
   
     ga('create', cookieControlDefaultAnalytics.googleAnalyticsId, 'auto')
     ga('send', 'pageview')
-    if (cookieControlDefaultAnalytics.track_events) {
+    //let trackEvents = cookieControlDefaultAnalytics.track_events;
+    // HACK
+    let trackEvents = true;
+    if (trackEvents) {
       window.analyticsWithConsent.gaAddEvents();
     }
     // End Google Analytics   
   },
-  gaAddEvents: function() {
+  gaAddEvents: function() {    
     window.analyticsWithConsent.gaAddOutboundEvents();
     window.analyticsWithConsent.gaAddDownloadEvents();
   },
-  gaAddOutboundEvents: function() {
+  gaAddOutboundEvents: function() {    
+
+    // HACK get domain via JS (from civicCookieControlDefaultAnalytics-js src)
+    // e.g. <script type='text/javascript' src='http://localhost/servicetransformation/wp-content/plugins/analytics-with-consent/assets/js/analytics.js?ver=5.7.2' id='civicCookieControlDefaultAnalytics-js'></script>
+    function getSiteUrl() {
+      let alink = document.getElementsByTagName('link')[0].href;
+      let siteurl = alink.substr(0, alink.indexOf('/wp-content'));
+      return siteurl;
+    }
+    //let siteurl = cookieControlDefaultAnalytics.siteurl;
+    let siteurl = getSiteUrl();    
+
     // check links
     $('a[href]').each(function() {
       // check if outbound (to another domain)
@@ -35,13 +49,15 @@ var analyticsWithConsent = {
       if (this.hasAttribute('target')) {
         target = this.getAttribute('target').toLowerCase();
       }
+
       if (link.indexOf('http') !== -1) {
-        if (link.indexOf(cookieControlDefaultAnalytics.siteurl) !== 0) {
+        if (link.indexOf(siteurl) !== 0) {
           isOutbound = true;
         }
       }
       // if outbound, add ga event
       if (isOutbound) {
+        console.log(link);
         this.onclick = function() {
           let label = fulllink;
           ga('send', 'event', 'outbound-link', fulllink, label, 0,

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -40,10 +40,11 @@ describe(Scripts::class, function () {
             });
             context('and Civic Product Type is set', function () {
                 it('enqueues the Civic Cookie Control script and the config and analytics scripts, and injects our settings, with the option to filter them', function () {
-                    allow('get_field')->toBeCalled()->andReturn('an_api_key', 'a_product_type', 'a_ga_id');
+                    allow('get_field')->toBeCalled()->andReturn('an_api_key', 'a_product_type', 'a_ga_id', [0 => '1']);
                     expect('get_field')->toBeCalled()->times(2)->with('civic_cookie_control_api_key', 'option');
                     expect('get_field')->toBeCalled()->times(2)->with('civic_cookie_control_product_type', 'option');
                     expect('get_field')->toBeCalled()->once()->with('google_analytics_id', 'option');
+                    expect('get_field')->toBeCalled()->once()->with('track_events', 'option');
                     allow('wp_enqueue_script')->toBeCalled();
                     expect('wp_enqueue_script')->toBeCalled()->once()->with('civicCookieControl', 'https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js');
                     allow('dirname')->toBeCalled()->andReturn('/path/to/this/plugin');
@@ -54,7 +55,9 @@ describe(Scripts::class, function () {
                     expect('wp_enqueue_script')->toBeCalled()->once()->with('civicCookieControlConfig', 'http://path/to/this/plugin/assets/js/config.js', ['civicCookieControl', 'civicCookieControlDefaultAnalytics']);
                     allow('wp_localize_script')->toBeCalled();
                     expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlDefaultAnalytics', 'cookieControlDefaultAnalytics', [
-                        'googleAnalyticsId' => 'a_ga_id'
+                        'googleAnalyticsId' => 'a_ga_id',
+                        'domain' => (parse_url(home_url()))['host'],
+                        'track_events' => '1'
                     ]);
                     allow('apply_filters')->toBeCalled()->andRun(function ($filterName, $filteredData) {
                         return $filteredData;

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -59,16 +59,20 @@ describe(Scripts::class, function () {
                     expect('wp_enqueue_script')->toBeCalled()->once()->with('civicCookieControlConfig', 'http://path/to/this/plugin/assets/js/config.js', ['civicCookieControl', 'civicCookieControlDefaultAnalytics']);
                     allow('wp_localize_script')->toBeCalled();
                     expect('wp_localize_script')->toBeCalled()->times(2)->with(
-                        'civicCookieControlDefaultAnalytics', 
-                        'cookieControlDefaultAnalytics', 
                         [
-                            'googleAnalyticsId' => 'a_ga_id',
-                            'siteurl' => 'https://www.example.com',
-                            'track_events' => true
+                            'civicCookieControlDefaultAnalytics', 
+                            'cookieControlDefaultAnalytics', 
+                            [
+                                'googleAnalyticsId' => 'a_ga_id',
+                                'siteurl' => 'https://www.example.com',
+                                'track_events' => true
+                            ],
                         ],
-                        'civicCookieControlConfig', 
-                        'cookieControlConfig', 
-                        \Kahlan\Arg::toBeAn('array')
+                        [
+                            'civicCookieControlConfig', 
+                            'cookieControlConfig', 
+                            \Kahlan\Arg::toBeAn('array')
+                        ]
                     );
                     allow('apply_filters')->toBeCalled()->andRun(function ($filterName, $filteredData) {
                         return $filteredData;

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -40,10 +40,11 @@ describe(Scripts::class, function () {
             });
             context('and Civic Product Type is set', function () {
                 it('enqueues the Civic Cookie Control script and the config and analytics scripts, and injects our settings, with the option to filter them', function () {
-                    allow('get_field')->toBeCalled()->andReturn('an_api_key', 'a_product_type', 'a_ga_id');
+                    allow('get_field')->toBeCalled()->andReturn('an_api_key', 'a_product_type', 'a_ga_id', true);
                     expect('get_field')->toBeCalled()->times(2)->with('civic_cookie_control_api_key', 'option');
                     expect('get_field')->toBeCalled()->times(2)->with('civic_cookie_control_product_type', 'option');
                     expect('get_field')->toBeCalled()->once()->with('google_analytics_id', 'option');
+                    expect('get_field')->toBeCalled()->once()->with('awc_track_events', 'option');
                     allow('wp_enqueue_script')->toBeCalled();
                     expect('wp_enqueue_script')->toBeCalled()->once()->with('civicCookieControl', 'https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js');
                     allow('dirname')->toBeCalled()->andReturn('/path/to/this/plugin');
@@ -54,7 +55,8 @@ describe(Scripts::class, function () {
                     expect('wp_enqueue_script')->toBeCalled()->once()->with('civicCookieControlConfig', 'http://path/to/this/plugin/assets/js/config.js', ['civicCookieControl', 'civicCookieControlDefaultAnalytics']);
                     allow('wp_localize_script')->toBeCalled();
                     expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlDefaultAnalytics', 'cookieControlDefaultAnalytics', [
-                        'googleAnalyticsId' => 'a_ga_id'
+                        'googleAnalyticsId' => 'a_ga_id',
+                        'track_events' => 'true'
                     ]);
                     allow('apply_filters')->toBeCalled()->andRun(function ($filterName, $filteredData) {
                         return $filteredData;

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -38,10 +38,10 @@ describe(Scripts::class, function () {
                     $this->scripts->enqueueScripts();
                 });
             });
+            function get_site_url() { return "https://www.example.com'"; }            
             context('and Civic Product Type is set', function () {
                 it('enqueues the Civic Cookie Control script and the config and analytics scripts, and injects our settings, with the option to filter them', function () {
-                    allow('get_field')->toBeCalled()->andReturn('an_api_key', 'a_product_type', 'a_ga_id', [0 => '1']);
-                    allow('get_site_url')->toBeCalled()->andReturn('https://www.example.com');
+                    allow('get_field')->toBeCalled()->andReturn('an_api_key', 'a_product_type', 'a_ga_id', [0 => '1']);                    
                     expect('get_field')->toBeCalled()->times(2)->with('civic_cookie_control_api_key', 'option');
                     expect('get_field')->toBeCalled()->times(2)->with('civic_cookie_control_product_type', 'option');
                     expect('get_field')->toBeCalled()->once()->with('google_analytics_id', 'option');

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -58,7 +58,7 @@ describe(Scripts::class, function () {
                     expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlDefaultAnalytics', 'cookieControlDefaultAnalytics', [
                         'googleAnalyticsId' => 'a_ga_id',
                         'siteurl' => 'https://www.example.com',
-                        'track_events' => '1'
+                        'track_events' => true
                     ]);
                     allow('apply_filters')->toBeCalled()->andRun(function ($filterName, $filteredData) {
                         return $filteredData;

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -38,10 +38,6 @@ describe(Scripts::class, function () {
                     $this->scripts->enqueueScripts();
                 });
             });
-            function get_site_url()
-            {
-                return "https://www.example.com'";
-            }
             context('and Civic Product Type is set', function () {
                 it('enqueues the Civic Cookie Control script and the config and analytics scripts, and injects our settings, with the option to filter them', function () {
                     allow('get_field')->toBeCalled()->andReturn('an_api_key', 'a_product_type', 'a_ga_id');

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -61,7 +61,6 @@ describe(Scripts::class, function () {
                     allow('wp_localize_script')->toBeCalled();
                     expect('wp_localize_script')->toBeCalled()->times(2)->with(
                         [
-                        0 => [
                             0 => "civicCookieControlDefaultAnalytics",
                             1 => "cookieControlDefaultAnalytics",
                             2 => [
@@ -70,7 +69,7 @@ describe(Scripts::class, function () {
                                 "siteurl" => "https://www.example.com'"
                             ]
                         ],
-                        1 => [
+                        [
                             0 => "civicCookieControlConfig",
                             1 => "cookieControlConfig",
                             2 => [
@@ -112,7 +111,6 @@ describe(Scripts::class, function () {
                                 ]
                             ]
                         ]
-                    ]
                     );
                     // expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlDefaultAnalytics', 'cookieControlDefaultAnalytics', [
                     //     'googleAnalyticsId' => 'a_ga_id',

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -41,6 +41,7 @@ describe(Scripts::class, function () {
             context('and Civic Product Type is set', function () {
                 it('enqueues the Civic Cookie Control script and the config and analytics scripts, and injects our settings, with the option to filter them', function () {
                     allow('get_field')->toBeCalled()->andReturn('an_api_key', 'a_product_type', 'a_ga_id', [0 => '1']);
+                    allow('get_site_url')->toBeCalled()->andReturn('https://www.example.com');
                     expect('get_field')->toBeCalled()->times(2)->with('civic_cookie_control_api_key', 'option');
                     expect('get_field')->toBeCalled()->times(2)->with('civic_cookie_control_product_type', 'option');
                     expect('get_field')->toBeCalled()->once()->with('google_analytics_id', 'option');
@@ -56,7 +57,7 @@ describe(Scripts::class, function () {
                     allow('wp_localize_script')->toBeCalled();
                     expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlDefaultAnalytics', 'cookieControlDefaultAnalytics', [
                         'googleAnalyticsId' => 'a_ga_id',
-                        'siteurl' => get_site_url(),
+                        'siteurl' => 'https://www.example.com',
                         'track_events' => '1'
                     ]);
                     allow('apply_filters')->toBeCalled()->andRun(function ($filterName, $filteredData) {

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -38,9 +38,14 @@ describe(Scripts::class, function () {
                     $this->scripts->enqueueScripts();
                 });
             });
+            // mock get_site_url() for tests
+            function get_site_url()
+            {
+                return "https://www.example.com'";
+            }
             context('and Civic Product Type is set', function () {
                 it('enqueues the Civic Cookie Control script and the config and analytics scripts, and injects our settings, with the option to filter them', function () {
-                    allow('get_field')->toBeCalled()->andReturn('an_api_key', 'a_product_type', 'a_ga_id', true);
+                    allow('get_field')->toBeCalled()->andReturn('an_api_key', 'a_product_type', 'a_ga_id', true, 'https://www.example.com');
                     expect('get_field')->toBeCalled()->times(2)->with('civic_cookie_control_api_key', 'option');
                     expect('get_field')->toBeCalled()->times(2)->with('civic_cookie_control_product_type', 'option');
                     expect('get_field')->toBeCalled()->once()->with('google_analytics_id', 'option');
@@ -56,7 +61,8 @@ describe(Scripts::class, function () {
                     allow('wp_localize_script')->toBeCalled();
                     expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlDefaultAnalytics', 'cookieControlDefaultAnalytics', [
                         'googleAnalyticsId' => 'a_ga_id',
-                        'track_events' => 'true'
+                        'track_events' => 'true',
+                        'siteurl' => 'https://www.example.com'
                     ]);
                     allow('apply_filters')->toBeCalled()->andRun(function ($filterName, $filteredData) {
                         return $filteredData;

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -65,7 +65,8 @@ describe(Scripts::class, function () {
                             "track_events" => true
                         ]
                     ];
-                    $wp_localize_script_params[1] = $this->scripts->defaultConfig();
+                    //$wp_localize_script_params[1] = $this->scripts->defaultConfig();
+                    $wp_localize_script_params[1] = \Kahlan\Arg::toBeAn('array');
                     expect('wp_localize_script')->toBeCalled()->times(2)->with($wp_localize_script_params);
                     allow('apply_filters')->toBeCalled()->andRun(function ($filterName, $filteredData) {
                         return $filteredData;

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -55,11 +55,18 @@ describe(Scripts::class, function () {
                     expect('plugins_url')->toBeCalled()->once()->with('/assets/js/config.js', '/path/to/this/plugin');
                     expect('wp_enqueue_script')->toBeCalled()->once()->with('civicCookieControlConfig', 'http://path/to/this/plugin/assets/js/config.js', ['civicCookieControl', 'civicCookieControlDefaultAnalytics']);
                     allow('wp_localize_script')->toBeCalled();
-                    expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlDefaultAnalytics', 'cookieControlDefaultAnalytics', [
-                        'googleAnalyticsId' => 'a_ga_id',
-                        'siteurl' => 'https://www.example.com',
-                        'track_events' => true
-                    ]);
+                    $wp_localize_script_params = [];
+                    $wp_localize_script_params[0] = [
+                        "civicCookieControlDefaultAnalytics",
+                         "cookieControlDefaultAnalytics",
+                        [
+                            "googleAnalyticsId" => "a_ga_id",
+                            "siteurl" => "https://www.example.com'",
+                            "track_events" => true
+                        ]
+                    ];
+                    $wp_localize_script_params[1] = $this->scripts->defaultConfig();
+                    expect('wp_localize_script')->toBeCalled()->times(2)->with($wp_localize_script_params);
                     allow('apply_filters')->toBeCalled()->andRun(function ($filterName, $filteredData) {
                         return $filteredData;
                     });

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -58,16 +58,23 @@ describe(Scripts::class, function () {
                     expect('plugins_url')->toBeCalled()->once()->with('/assets/js/config.js', '/path/to/this/plugin');
                     expect('wp_enqueue_script')->toBeCalled()->once()->with('civicCookieControlConfig', 'http://path/to/this/plugin/assets/js/config.js', ['civicCookieControl', 'civicCookieControlDefaultAnalytics']);
                     allow('wp_localize_script')->toBeCalled();
-                    expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlDefaultAnalytics', 'cookieControlDefaultAnalytics', [
-                        'googleAnalyticsId' => 'a_ga_id',
-                        'siteurl' => 'https://www.example.com',
-                        'track_events' => true
-                    ]);
+                    expect('wp_localize_script')->toBeCalled()->times(2)->with(
+                        'civicCookieControlDefaultAnalytics', 
+                        'cookieControlDefaultAnalytics', 
+                        [
+                            'googleAnalyticsId' => 'a_ga_id',
+                            'siteurl' => 'https://www.example.com',
+                            'track_events' => true
+                        ],
+                        'civicCookieControlConfig', 
+                        'cookieControlConfig', 
+                        \Kahlan\Arg::toBeAn('array')
+                    );
                     allow('apply_filters')->toBeCalled()->andRun(function ($filterName, $filteredData) {
                         return $filteredData;
                     });
                     expect('apply_filters')->toBeCalled()->once()->with('awc_civic_cookie_control_config', \Kahlan\Arg::toBeAn('array'));
-                    expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlConfig', 'cookieControlConfig', \Kahlan\Arg::toBeAn('array'));
+                    //expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlConfig', 'cookieControlConfig', \Kahlan\Arg::toBeAn('array'));
                     $this->scripts->enqueueScripts();
                 });
             });

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -59,7 +59,7 @@ describe(Scripts::class, function () {
                     expect('plugins_url')->toBeCalled()->once()->with('/assets/js/config.js', '/path/to/this/plugin');
                     expect('wp_enqueue_script')->toBeCalled()->once()->with('civicCookieControlConfig', 'http://path/to/this/plugin/assets/js/config.js', ['civicCookieControl', 'civicCookieControlDefaultAnalytics']);
                     allow('wp_localize_script')->toBeCalled();
-                    expect('wp_localize_script')->toBeCalled()->twice()->with(
+                    expect('wp_localize_script')->toBeCalled()->times(2)->with(
                         [
                         0 => [
                             0 => "civicCookieControlDefaultAnalytics",

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -56,7 +56,7 @@ describe(Scripts::class, function () {
                     allow('wp_localize_script')->toBeCalled();
                     expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlDefaultAnalytics', 'cookieControlDefaultAnalytics', [
                         'googleAnalyticsId' => 'a_ga_id',
-                        'domain' => (parse_url(home_url()))['host'],
+                        'siteurl' => get_site_url(),
                         'track_events' => '1'
                     ]);
                     allow('apply_filters')->toBeCalled()->andRun(function ($filterName, $filteredData) {

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -38,10 +38,13 @@ describe(Scripts::class, function () {
                     $this->scripts->enqueueScripts();
                 });
             });
-            function get_site_url() { return "https://www.example.com'"; }            
+            function get_site_url()
+            {
+                return "https://www.example.com'";
+            }
             context('and Civic Product Type is set', function () {
                 it('enqueues the Civic Cookie Control script and the config and analytics scripts, and injects our settings, with the option to filter them', function () {
-                    allow('get_field')->toBeCalled()->andReturn('an_api_key', 'a_product_type', 'a_ga_id', [0 => '1']);                    
+                    allow('get_field')->toBeCalled()->andReturn('an_api_key', 'a_product_type', 'a_ga_id', [0 => '1']);
                     expect('get_field')->toBeCalled()->times(2)->with('civic_cookie_control_api_key', 'option');
                     expect('get_field')->toBeCalled()->times(2)->with('civic_cookie_control_product_type', 'option');
                     expect('get_field')->toBeCalled()->once()->with('google_analytics_id', 'option');
@@ -55,19 +58,11 @@ describe(Scripts::class, function () {
                     expect('plugins_url')->toBeCalled()->once()->with('/assets/js/config.js', '/path/to/this/plugin');
                     expect('wp_enqueue_script')->toBeCalled()->once()->with('civicCookieControlConfig', 'http://path/to/this/plugin/assets/js/config.js', ['civicCookieControl', 'civicCookieControlDefaultAnalytics']);
                     allow('wp_localize_script')->toBeCalled();
-                    $wp_localize_script_params = [];
-                    $wp_localize_script_params[0] = [
-                        "civicCookieControlDefaultAnalytics",
-                         "cookieControlDefaultAnalytics",
-                        [
-                            "googleAnalyticsId" => "a_ga_id",
-                            "siteurl" => "https://www.example.com'",
-                            "track_events" => true
-                        ]
-                    ];
-                    //$wp_localize_script_params[1] = $this->scripts->defaultConfig();
-                    $wp_localize_script_params[1] = \Kahlan\Arg::toBeAn('array');
-                    expect('wp_localize_script')->toBeCalled()->times(2)->with($wp_localize_script_params);
+                    expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlDefaultAnalytics', 'cookieControlDefaultAnalytics', [
+                        'googleAnalyticsId' => 'a_ga_id',
+                        'siteurl' => 'https://www.example.com',
+                        'track_events' => true
+                    ]);
                     allow('apply_filters')->toBeCalled()->andRun(function ($filterName, $filteredData) {
                         return $filteredData;
                     });

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -59,16 +59,71 @@ describe(Scripts::class, function () {
                     expect('plugins_url')->toBeCalled()->once()->with('/assets/js/config.js', '/path/to/this/plugin');
                     expect('wp_enqueue_script')->toBeCalled()->once()->with('civicCookieControlConfig', 'http://path/to/this/plugin/assets/js/config.js', ['civicCookieControl', 'civicCookieControlDefaultAnalytics']);
                     allow('wp_localize_script')->toBeCalled();
-                    expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlDefaultAnalytics', 'cookieControlDefaultAnalytics', [
-                        'googleAnalyticsId' => 'a_ga_id',
-                        'track_events' => 'true',
-                        'siteurl' => 'https://www.example.com'
-                    ]);
+                    expect('wp_localize_script')->toBeCalled()->twice()->with(
+                        [
+                        0 => [
+                            0 => "civicCookieControlDefaultAnalytics",
+                            1 => "cookieControlDefaultAnalytics",
+                            2 => [
+                                "googleAnalyticsId" => "a_ga_id",
+                                "track_events" => true,
+                                "siteurl" => "https://www.example.com'"
+                            ]
+                        ],
+                        1 => [
+                            0 => "civicCookieControlConfig",
+                            1 => "cookieControlConfig",
+                            2 => [
+                                "apiKey" => "https://www.example.com",
+                                "product" => "https://www.example.com",
+                                "closeStyle" => "button",
+                                "initialState" => "open",
+                                "text" => [
+                                    "closeLabel" => "Save and Close",
+                                    "acceptSettings" => "Accept all cookies",
+                                    "rejectSettings" => "Only accept necessary cookies"
+                                ],
+                                "branding" => [
+                                    "removeAbout" => true
+                                ],
+                                "position" => "LEFT",
+                                "theme" => "DARK",
+                                "subDomains" => false,
+                                "toggleType" => "checkbox",
+                                "optionalCookies" => [
+                                    0 => [
+                                        "name" => "analytics",
+                                        "label" => "Analytical Cookies",
+                                        "description" => "Analytical cookies help us to improve our website by collecting and reporting information on its usage.",
+                                        "cookies" => [
+                                            0 => "_ga",
+                                            1 => "_gid",
+                                            2 => "_gat",
+                                            3 => "__utma",
+                                            4 => "__utmt",
+                                            5 => "__utmb",
+                                            6 => "__utmc",
+                                            7 => "__utmz",
+                                            8 => "__utmv"
+                                        ],
+                                        "onAccept" => "analyticsWithConsent.gaAccept",
+                                        "onRevoke" => "analyticsWithConsent.gaRevoke"
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                    );
+                    // expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlDefaultAnalytics', 'cookieControlDefaultAnalytics', [
+                    //     'googleAnalyticsId' => 'a_ga_id',
+                    //     'track_events' => 'true',
+                    //     'siteurl' => 'https://www.example.com'
+                    // ]);
                     allow('apply_filters')->toBeCalled()->andRun(function ($filterName, $filteredData) {
                         return $filteredData;
                     });
                     expect('apply_filters')->toBeCalled()->once()->with('awc_civic_cookie_control_config', \Kahlan\Arg::toBeAn('array'));
-                    expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlConfig', 'cookieControlConfig', \Kahlan\Arg::toBeAn('array'));
+                    //expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlConfig', 'cookieControlConfig', \Kahlan\Arg::toBeAn('array'));
                     $this->scripts->enqueueScripts();
                 });
             });

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -71,7 +71,7 @@ describe(Scripts::class, function () {
                         [
                             'civicCookieControlConfig', 
                             'cookieControlConfig', 
-                            \Kahlan\Arg::toBeAn('array')
+                            $this->scripts->getDefaultConfig()
                         ]
                     );
                     allow('apply_filters')->toBeCalled()->andRun(function ($filterName, $filteredData) {

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -44,11 +44,10 @@ describe(Scripts::class, function () {
             }
             context('and Civic Product Type is set', function () {
                 it('enqueues the Civic Cookie Control script and the config and analytics scripts, and injects our settings, with the option to filter them', function () {
-                    allow('get_field')->toBeCalled()->andReturn('an_api_key', 'a_product_type', 'a_ga_id', [0 => '1']);
+                    allow('get_field')->toBeCalled()->andReturn('an_api_key', 'a_product_type', 'a_ga_id');
                     expect('get_field')->toBeCalled()->times(2)->with('civic_cookie_control_api_key', 'option');
                     expect('get_field')->toBeCalled()->times(2)->with('civic_cookie_control_product_type', 'option');
                     expect('get_field')->toBeCalled()->once()->with('google_analytics_id', 'option');
-                    expect('get_field')->toBeCalled()->once()->with('track_events', 'option');
                     allow('wp_enqueue_script')->toBeCalled();
                     expect('wp_enqueue_script')->toBeCalled()->once()->with('civicCookieControl', 'https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js');
                     allow('dirname')->toBeCalled()->andReturn('/path/to/this/plugin');
@@ -58,27 +57,14 @@ describe(Scripts::class, function () {
                     expect('plugins_url')->toBeCalled()->once()->with('/assets/js/config.js', '/path/to/this/plugin');
                     expect('wp_enqueue_script')->toBeCalled()->once()->with('civicCookieControlConfig', 'http://path/to/this/plugin/assets/js/config.js', ['civicCookieControl', 'civicCookieControlDefaultAnalytics']);
                     allow('wp_localize_script')->toBeCalled();
-                    expect('wp_localize_script')->toBeCalled()->times(2)->with(
-                        [
-                            'civicCookieControlDefaultAnalytics', 
-                            'cookieControlDefaultAnalytics', 
-                            [
-                                'googleAnalyticsId' => 'a_ga_id',
-                                'siteurl' => 'https://www.example.com',
-                                'track_events' => true
-                            ],
-                        ],
-                        [
-                            'civicCookieControlConfig', 
-                            'cookieControlConfig', 
-                            $this->scripts->getDefaultConfig()
-                        ]
-                    );
+                    expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlDefaultAnalytics', 'cookieControlDefaultAnalytics', [
+                        'googleAnalyticsId' => 'a_ga_id'
+                    ]);
                     allow('apply_filters')->toBeCalled()->andRun(function ($filterName, $filteredData) {
                         return $filteredData;
                     });
                     expect('apply_filters')->toBeCalled()->once()->with('awc_civic_cookie_control_config', \Kahlan\Arg::toBeAn('array'));
-                    //expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlConfig', 'cookieControlConfig', \Kahlan\Arg::toBeAn('array'));
+                    expect('wp_localize_script')->toBeCalled()->once()->with('civicCookieControlConfig', 'cookieControlConfig', \Kahlan\Arg::toBeAn('array'));
                     $this->scripts->enqueueScripts();
                 });
             });

--- a/src/Options.php
+++ b/src/Options.php
@@ -84,6 +84,31 @@ class Options implements \Dxw\Iguana\Registerable
                     'return_format' => 'value',
                     'ajax' => 0,
                     'placeholder' => '',
+                ],
+                [
+                    'key' => 'field_5fad0790934c7',
+                    'label' => 'Track Events',
+                    'name' => 'track_events',
+                    'type' => 'checkbox',
+                    'instructions' => 'Whether to also track events (if user consents to analytics)',
+                    'required' => 0,
+                    'conditional_logic' => 0,
+                    'wrapper' => [
+                        'width' => '',
+                        'class' => '',
+                        'id' => '',
+                    ],
+                    'choices' => [
+                        '1' => 'Allow'
+                    ],
+                    'layout' => 'vertical',
+                    'default_value' => 0,
+                    'allow_null' => 0,
+                    'multiple' => 0,
+                    'ui' => 0,
+                    'return_format' => 'value',
+                    'ajax' => 0,
+                    'placeholder' => '',
                 ]
             ],
             'location' => [

--- a/src/Options.php
+++ b/src/Options.php
@@ -86,11 +86,12 @@ class Options implements \Dxw\Iguana\Registerable
                     'placeholder' => '',
                 ],
                 [
-                    'key' => 'field_5fad0790934c7',
+                    'key' => 'field_6fad0790934d9',
                     'label' => 'Track Events',
-                    'name' => 'track_events',
-                    'type' => 'checkbox',
+                    'name' => 'awc_track_events',
+                    'type' => 'true_false',
                     'instructions' => 'Whether to also track events (if user consents to analytics)',
+                    'message' => 'Allow',
                     'required' => 0,
                     'conditional_logic' => 0,
                     'wrapper' => [
@@ -98,13 +99,9 @@ class Options implements \Dxw\Iguana\Registerable
                         'class' => '',
                         'id' => '',
                     ],
-                    'choices' => [
-                        '1' => 'Allow'
-                    ],
                     'layout' => 'vertical',
-                    'default_value' => 0,
+                    'default_value' => 1,
                     'allow_null' => 0,
-                    'multiple' => 0,
                     'ui' => 0,
                     'return_format' => 'value',
                     'ajax' => 0,

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -7,7 +7,7 @@ class Scripts implements \Dxw\Iguana\Registerable
     public function register() : void
     {
         add_action('wp_enqueue_scripts', [$this, 'enqueueScripts']);
-        add_action('wp_enqueue_scripts', [$this, 'enqueueStyles']);
+        add_action('wp_enqueue_scripts', [$this, 'enqueueStyles']);        
     }
 
     public function enqueueScripts() : void
@@ -15,6 +15,7 @@ class Scripts implements \Dxw\Iguana\Registerable
         $apiKey = get_field('civic_cookie_control_api_key', 'option');
         $productType = get_field('civic_cookie_control_product_type', 'option');
         $googleAnalyticsId = get_field('google_analytics_id', 'option');
+        include_once('wp-includes\option.php'); // needed for tests
         $siteurl = get_site_url();
         $track_events_option = get_field('track_events', 'option');
         $track_events = isset($track_events_option[0]) && $track_events_option[0] == '1';

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -14,7 +14,7 @@ class Scripts implements \Dxw\Iguana\Registerable
     {
         $apiKey = get_field('civic_cookie_control_api_key', 'option');
         $productType = get_field('civic_cookie_control_product_type', 'option');
-        $googleAnalyticsId = get_field('google_analytics_id', 'option');        
+        $googleAnalyticsId = get_field('google_analytics_id', 'option');
         $siteurl = get_site_url();
         $track_events_option = get_field('track_events', 'option');
         $track_events = isset($track_events_option[0]) && $track_events_option[0] == '1';

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -15,16 +15,11 @@ class Scripts implements \Dxw\Iguana\Registerable
         $apiKey = get_field('civic_cookie_control_api_key', 'option');
         $productType = get_field('civic_cookie_control_product_type', 'option');
         $googleAnalyticsId = get_field('google_analytics_id', 'option');
-        $siteurl = get_site_url();
-        $track_events_option = get_field('track_events', 'option');
-        $track_events = isset($track_events_option[0]) && $track_events_option[0] == '1';
         if ($apiKey && $productType) {
             wp_enqueue_script('civicCookieControl', 'https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js');
             wp_enqueue_script('civicCookieControlDefaultAnalytics', plugins_url('/assets/js/analytics.js', dirname(__FILE__)), ['civicCookieControl']);
             wp_localize_script('civicCookieControlDefaultAnalytics', 'cookieControlDefaultAnalytics', [
-                'googleAnalyticsId' => $googleAnalyticsId,
-                'siteurl' => $siteurl,
-                'track_events' => $track_events
+                'googleAnalyticsId' => $googleAnalyticsId
             ]);
             wp_enqueue_script('civicCookieControlConfig', plugins_url('/assets/js/config.js', dirname(__FILE__)), ['civicCookieControl', 'civicCookieControlDefaultAnalytics']);
             wp_localize_script('civicCookieControlConfig', 'cookieControlConfig', $this->defaultConfig());
@@ -66,10 +61,5 @@ class Scripts implements \Dxw\Iguana\Registerable
                 ]
             ]
         ]);
-    }
-
-    public function getDefaultConfig() : array
-    {
-        return $this->defaultConfig();
     }
 }

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -15,7 +15,7 @@ class Scripts implements \Dxw\Iguana\Registerable
         $apiKey = get_field('civic_cookie_control_api_key', 'option');
         $productType = get_field('civic_cookie_control_product_type', 'option');
         $googleAnalyticsId = get_field('google_analytics_id', 'option');
-        $domain = $_SERVER['HTTP_HOST'];
+        $domain = (parse_url(home_url()))['host'];
         $track_events_option = get_field('track_events', 'option');
         $track_events = isset($track_events_option[0]) && $track_events_option[0] == '1';
         if ($apiKey && $productType) {

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -15,11 +15,16 @@ class Scripts implements \Dxw\Iguana\Registerable
         $apiKey = get_field('civic_cookie_control_api_key', 'option');
         $productType = get_field('civic_cookie_control_product_type', 'option');
         $googleAnalyticsId = get_field('google_analytics_id', 'option');
+        $domain = $_SERVER['HTTP_HOST'];
+        $track_events_option = get_field('track_events', 'option');
+        $track_events = isset($track_events_option[0]) && $track_events_option[0] == '1';
         if ($apiKey && $productType) {
             wp_enqueue_script('civicCookieControl', 'https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js');
             wp_enqueue_script('civicCookieControlDefaultAnalytics', plugins_url('/assets/js/analytics.js', dirname(__FILE__)), ['civicCookieControl']);
             wp_localize_script('civicCookieControlDefaultAnalytics', 'cookieControlDefaultAnalytics', [
-                'googleAnalyticsId' => $googleAnalyticsId
+                'googleAnalyticsId' => $googleAnalyticsId,
+                'domain' => $domain,
+                'track_events' => $track_events
             ]);
             wp_enqueue_script('civicCookieControlConfig', plugins_url('/assets/js/config.js', dirname(__FILE__)), ['civicCookieControl', 'civicCookieControlDefaultAnalytics']);
             wp_localize_script('civicCookieControlConfig', 'cookieControlConfig', $this->defaultConfig());

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -67,4 +67,9 @@ class Scripts implements \Dxw\Iguana\Registerable
             ]
         ]);
     }
+
+    public function getDefaultConfig() : array
+    {
+        return $this->defaultConfig();
+    }
 }

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -7,15 +7,14 @@ class Scripts implements \Dxw\Iguana\Registerable
     public function register() : void
     {
         add_action('wp_enqueue_scripts', [$this, 'enqueueScripts']);
-        add_action('wp_enqueue_scripts', [$this, 'enqueueStyles']);        
+        add_action('wp_enqueue_scripts', [$this, 'enqueueStyles']);
     }
 
     public function enqueueScripts() : void
     {
         $apiKey = get_field('civic_cookie_control_api_key', 'option');
         $productType = get_field('civic_cookie_control_product_type', 'option');
-        $googleAnalyticsId = get_field('google_analytics_id', 'option');
-        include_once('wp-includes\option.php'); // needed for tests
+        $googleAnalyticsId = get_field('google_analytics_id', 'option');        
         $siteurl = get_site_url();
         $track_events_option = get_field('track_events', 'option');
         $track_events = isset($track_events_option[0]) && $track_events_option[0] == '1';

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -20,12 +20,14 @@ class Scripts implements \Dxw\Iguana\Registerable
         if (!$track_events) {
             $track_events = true;
         }
+        $siteurl = get_site_url();
         if ($apiKey && $productType) {
             wp_enqueue_script('civicCookieControl', 'https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js');
             wp_enqueue_script('civicCookieControlDefaultAnalytics', plugins_url('/assets/js/analytics.js', dirname(__FILE__)), ['civicCookieControl']);
             wp_localize_script('civicCookieControlDefaultAnalytics', 'cookieControlDefaultAnalytics', [
                 'googleAnalyticsId' => $googleAnalyticsId,
-                'track_events' => $track_events
+                'track_events' => $track_events,
+                'siteurl' => $siteurl
             ]);
             wp_enqueue_script('civicCookieControlConfig', plugins_url('/assets/js/config.js', dirname(__FILE__)), ['civicCookieControl', 'civicCookieControlDefaultAnalytics']);
             wp_localize_script('civicCookieControlConfig', 'cookieControlConfig', $this->defaultConfig());

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -15,7 +15,7 @@ class Scripts implements \Dxw\Iguana\Registerable
         $apiKey = get_field('civic_cookie_control_api_key', 'option');
         $productType = get_field('civic_cookie_control_product_type', 'option');
         $googleAnalyticsId = get_field('google_analytics_id', 'option');
-        $siteurl = get_site_url();        
+        $siteurl = get_site_url();
         $track_events_option = get_field('track_events', 'option');
         $track_events = isset($track_events_option[0]) && $track_events_option[0] == '1';
         if ($apiKey && $productType) {

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -5,7 +5,7 @@ namespace AnalyticsWithConsent;
 class Scripts implements \Dxw\Iguana\Registerable
 {
     public function register() : void
-    {        
+    {
         add_action('wp_enqueue_scripts', [$this, 'enqueueScripts']);
         add_action('wp_enqueue_scripts', [$this, 'enqueueStyles']);
     }
@@ -17,12 +17,15 @@ class Scripts implements \Dxw\Iguana\Registerable
         $googleAnalyticsId = get_field('google_analytics_id', 'option');
         // get track_events option, defaulting to true if not set
         $track_events = get_field('awc_track_events', 'option');
-        if (!$track_events) { $track_events = true; }
+        if (!$track_events) {
+            $track_events = true;
+        }
         if ($apiKey && $productType) {
             wp_enqueue_script('civicCookieControl', 'https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js');
             wp_enqueue_script('civicCookieControlDefaultAnalytics', plugins_url('/assets/js/analytics.js', dirname(__FILE__)), ['civicCookieControl']);
             wp_localize_script('civicCookieControlDefaultAnalytics', 'cookieControlDefaultAnalytics', [
-                'googleAnalyticsId' => $googleAnalyticsId
+                'googleAnalyticsId' => $googleAnalyticsId,
+                'track_events' => $track_events
             ]);
             wp_enqueue_script('civicCookieControlConfig', plugins_url('/assets/js/config.js', dirname(__FILE__)), ['civicCookieControl', 'civicCookieControlDefaultAnalytics']);
             wp_localize_script('civicCookieControlConfig', 'cookieControlConfig', $this->defaultConfig());

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -15,7 +15,7 @@ class Scripts implements \Dxw\Iguana\Registerable
         $apiKey = get_field('civic_cookie_control_api_key', 'option');
         $productType = get_field('civic_cookie_control_product_type', 'option');
         $googleAnalyticsId = get_field('google_analytics_id', 'option');
-        $domain = (parse_url(home_url()))['host'];
+        $siteurl = get_site_url();        
         $track_events_option = get_field('track_events', 'option');
         $track_events = isset($track_events_option[0]) && $track_events_option[0] == '1';
         if ($apiKey && $productType) {
@@ -23,7 +23,7 @@ class Scripts implements \Dxw\Iguana\Registerable
             wp_enqueue_script('civicCookieControlDefaultAnalytics', plugins_url('/assets/js/analytics.js', dirname(__FILE__)), ['civicCookieControl']);
             wp_localize_script('civicCookieControlDefaultAnalytics', 'cookieControlDefaultAnalytics', [
                 'googleAnalyticsId' => $googleAnalyticsId,
-                'domain' => $domain,
+                'siteurl' => $siteurl,
                 'track_events' => $track_events
             ]);
             wp_enqueue_script('civicCookieControlConfig', plugins_url('/assets/js/config.js', dirname(__FILE__)), ['civicCookieControl', 'civicCookieControlDefaultAnalytics']);

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -5,7 +5,7 @@ namespace AnalyticsWithConsent;
 class Scripts implements \Dxw\Iguana\Registerable
 {
     public function register() : void
-    {
+    {        
         add_action('wp_enqueue_scripts', [$this, 'enqueueScripts']);
         add_action('wp_enqueue_scripts', [$this, 'enqueueStyles']);
     }
@@ -15,6 +15,9 @@ class Scripts implements \Dxw\Iguana\Registerable
         $apiKey = get_field('civic_cookie_control_api_key', 'option');
         $productType = get_field('civic_cookie_control_product_type', 'option');
         $googleAnalyticsId = get_field('google_analytics_id', 'option');
+        // get track_events option, defaulting to true if not set
+        $track_events = get_field('awc_track_events', 'option');
+        if (!$track_events) { $track_events = true; }
         if ($apiKey && $productType) {
             wp_enqueue_script('civicCookieControl', 'https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js');
             wp_enqueue_script('civicCookieControlDefaultAnalytics', plugins_url('/assets/js/analytics.js', dirname(__FILE__)), ['civicCookieControl']);


### PR DESCRIPTION
- To track document downloads and outbound links
- Add setting to Analytics with Consent plugin to toggle event tracking

- Resolves: https://dxw.zendesk.com/agent/tickets/14067