### PR TITLE
Feature/gtm marketing cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Option to include marketing scripts via GTM
+
 ## [1.2.0] - 2022-09-13
 
 - Google Tag Manager functionality

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -25,9 +25,6 @@ var analyticsWithConsent = {
 
     // GTM
     if (cookieControlDefaultAnalytics.gtmId !== '') {
-        window.dataLayer = window.dataLayer || [];
-        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer',cookieControlDefaultAnalytics.gtmId);
         gtag('consent', 'update', {
             'analytics_storage': 'granted'
         });

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -25,9 +25,9 @@ var analyticsWithConsent = {
 
     // GTM
     if (cookieControlDefaultAnalytics.gtmId !== '') {
-        gtag('consent', 'update', {
-            'analytics_storage': 'granted'
-        });
+      gtag('consent', 'update', {
+        'analytics_storage': 'granted'
+      });
     }
     // End GTM
   },
@@ -46,9 +46,9 @@ var analyticsWithConsent = {
     // End GA4
     // Disable GTM
     if (cookieControlDefaultAnalytics.gtmId !== '') {
-        gtag('consent', 'update', {
-            'analytics_storage': 'denied'
-        });
+      gtag('consent', 'update', {
+        'analytics_storage': 'denied'
+      });
     }
     // End GTM
   }

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -51,6 +51,16 @@ var analyticsWithConsent = {
       });
     }
     // End GTM
+  },
+  marketingAccept: function () {
+    gtag('consent', 'update', {
+      'ad_storage' : 'granted'
+    });
+  },
+  marketingRevoke: function () {
+    gtag('consent', 'update', {
+      'ad_storage' : 'denied'
+    });
   }
 }
 var gtag = function () { dataLayer.push(arguments) }

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -10,10 +10,10 @@ var analyticsWithConsent = {
         }, i[r].l = 1 * new Date(); a = s.createElement(o),
         m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
       })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga')
-    
+
       ga('create', cookieControlDefaultAnalytics.googleAnalyticsId, 'auto')
-      ga('send', 'pageview')        
-    }   
+      ga('send', 'pageview')
+    }
     // End Google Analytics (UA)
     // Add GA4
     if (cookieControlDefaultAnalytics.ga4Id !== '') {
@@ -57,7 +57,7 @@ var analyticsWithConsent = {
   }
 }
 var gtag = function () { dataLayer.push(arguments) }
-window.dataLayer = window.dataLayer || []    
+window.dataLayer = window.dataLayer || []
 gtag('consent', 'default', {
   'ad_storage': 'denied',
   'analytics_storage': 'denied'

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -14,10 +14,11 @@ describe(Scripts::class, function () {
     describe('->register()', function () {
         it('adds actions', function () {
             allow('add_action')->toBeCalled();
-            expect('add_action')->toBeCalled()->times(3);
+            expect('add_action')->toBeCalled()->times(4);
             expect('add_action')->toBeCalled()->with('wp_enqueue_scripts', [$this->scripts, 'enqueueScripts']);
             expect('add_action')->toBeCalled()->with('wp_enqueue_scripts', [$this->scripts, 'enqueueStyles']);
             expect('add_action')->toBeCalled()->with('wp_head', [$this->scripts, 'addGA4']);
+            expect('add_action')->toBeCalled()->with('wp_head', [$this->scripts, 'addGTM']);
             $this->scripts->register();
         });
     });
@@ -87,7 +88,7 @@ describe(Scripts::class, function () {
         context('API Key is not set', function () {
             it('does nothing', function () {
                 allow('get_field')->toBeCalled()->andReturn(null, 'a_product_type', 'a_ga4_id');
-                
+
                 ob_start();
                 $this->scripts->addGA4();
                 $result = ob_get_clean();
@@ -98,7 +99,7 @@ describe(Scripts::class, function () {
         context('product type is not set', function () {
             it('does nothing', function () {
                 allow('get_field')->toBeCalled()->andReturn('an_api_key', null, 'a_ga4_id');
-                
+
                 ob_start();
                 $this->scripts->addGA4();
                 $result = ob_get_clean();
@@ -109,7 +110,7 @@ describe(Scripts::class, function () {
         context('GA4 ID is not set', function () {
             it('does nothing', function () {
                 allow('get_field')->toBeCalled()->andReturn('an_api_key', 'a_product_type', null);
-                
+
                 ob_start();
                 $this->scripts->addGA4();
                 $result = ob_get_clean();
@@ -123,12 +124,62 @@ describe(Scripts::class, function () {
                 allow('esc_attr')->toBeCalled()->andRun(function ($input) {
                     return $input;
                 });
-                
+
                 ob_start();
                 $this->scripts->addGA4();
                 $result = ob_get_clean();
 
                 expect($result)->toEqual('<script async id="awc_gtag" src="https://www.googletagmanager.com/gtag/js?id=123456"></script>');
+            });
+        });
+    });
+
+    describe('->addGTM()', function () {
+        context('API Key is not set', function () {
+            it('does nothing', function () {
+                allow('get_field')->toBeCalled()->andReturn(null, 'a_product_type', 'a_gtm_id');
+
+                ob_start();
+                $this->scripts->addGTM();
+                $result = ob_get_clean();
+
+                expect($result)->toEqual('');
+            });
+        });
+        context('product type is not set', function () {
+            it('does nothing', function () {
+                allow('get_field')->toBeCalled()->andReturn('an_api_key', null, 'a_gtm_id');
+
+                ob_start();
+                $this->scripts->addGTM();
+                $result = ob_get_clean();
+
+                expect($result)->toEqual('');
+            });
+        });
+        context('GTM ID is not set', function () {
+            it('does nothing', function () {
+                allow('get_field')->toBeCalled()->andReturn('an_api_key', 'a_product_type', null);
+
+                ob_start();
+                $this->scripts->addGTM();
+                $result = ob_get_clean();
+
+                expect($result)->toEqual('');
+            });
+        });
+        context('API Key, product type and GTM ID are set', function () {
+            it('outputs the GTM script tag', function () {
+                allow('get_field')->toBeCalled()->andReturn('an_api_key', 'a_product_type', '123456');
+                allow('esc_js')->toBeCalled()->andRun(function ($input) {
+                    return $input;
+                });
+
+                ob_start();
+                $this->scripts->addGTM();
+                $result = ob_get_clean();
+
+                expect($result)->toContain("window,document,'script','dataLayer','123456'");
             });
         });
     });

--- a/src/Options.php
+++ b/src/Options.php
@@ -64,7 +64,7 @@ class Options implements \Dxw\Iguana\Registerable
                     'label' => 'Google Analytics GTM',
                     'name' => 'google_analytics_gtm',
                     'type' => 'text',
-                    'instructions' => 'Please note: GTM should only be used for embedding Google Analytics, because the cookie consent mechanism will not cover other scripts that could be embedded via GTM.',
+                    'instructions' => '',
                     'required' => 0,
                     'conditional_logic' => 0,
                     'wrapper' => [

--- a/src/Options.php
+++ b/src/Options.php
@@ -79,6 +79,55 @@ class Options implements \Dxw\Iguana\Registerable
                     'maxlength' => '',
                 ],
                 [
+                    'key' => 'field_4024de106295e',
+                    'label' => 'Include GTM marketing consent?',
+                    'name' => 'gtm_marketing_consent',
+                    'type' => 'true_false',
+                    'instructions' => 'If you tick this, then the plugin will control GTM\'s "ad_storage" state, as well as the "analytics_storage" state.',
+                    'required' => 0,
+                    'conditional_logic' => [
+                        [
+                            [
+                                'field' => 'field_5f986ab76a820',
+                                'operator' => '!=empty',
+                            ],
+                        ],
+                    ],
+                    'wrapper' => [
+                        'width' => '',
+                        'class' => '',
+                        'id' => '',
+                    ],
+                    'default_value' => ''
+                ],
+                [
+                    'key' => 'field_634548a37c19d',
+                    'label' => 'GTM Marketing cookies',
+                    'name' => 'gtm_marketing_cookies',
+                    'type' => 'text',
+                    'instructions' => 'The marketing cookies that will be set by GTM. Should be formatted as a comma-separated list, in single quotes, e.g. \'cookie_1\', \'cookie_2\',\'cookie_3\'',
+                    'required' => 0,
+                    'conditional_logic' => [
+                        [
+                            [
+                                'field' => 'field_4024de106295e',
+                                'operator' => '==',
+                                'value' => '1',
+                            ],
+                        ],
+                    ],
+                    'wrapper' => [
+                        'width' => '',
+                        'class' => '',
+                        'id' => '',
+                    ],
+                    'default_value' => '',
+                    'maxlength' => '',
+                    'placeholder' => '',
+                    'prepend' => '',
+                    'append' => '',
+                ],
+                [
                     'key' => 'field_5f986ace6a81a',
                     'label' => 'CIVIC Cookie Control API key',
                     'name' => 'civic_cookie_control_api_key',

--- a/src/Options.php
+++ b/src/Options.php
@@ -64,7 +64,7 @@ class Options implements \Dxw\Iguana\Registerable
                     'label' => 'Google Analytics GTM',
                     'name' => 'google_analytics_gtm',
                     'type' => 'text',
-                    'instructions' => '',
+                    'instructions' => 'Note: if you use GTM, it is up to you to configure GTM correctly to ensure it checks for "ad_storage" and/or "analytics_storage" consent status when adding scripts.',
                     'required' => 0,
                     'conditional_logic' => 0,
                     'wrapper' => [
@@ -105,7 +105,7 @@ class Options implements \Dxw\Iguana\Registerable
                     'label' => 'GTM Marketing cookies',
                     'name' => 'gtm_marketing_cookies',
                     'type' => 'text',
-                    'instructions' => 'The marketing cookies that will be set by GTM. Should be formatted as a comma-separated list, in single quotes, e.g. \'cookie_1\', \'cookie_2\',\'cookie_3\'',
+                    'instructions' => 'The marketing cookies that will be set by GTM. Should be formatted as a comma-separated list, without quotes, e.g. cookie_1,cookie_2,cookie_3',
                     'required' => 0,
                     'conditional_logic' => [
                         [

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -59,6 +59,26 @@ class Scripts implements \Dxw\Iguana\Registerable
 
     private function defaultConfig() : array
     {
+        $optionalCookies = [
+            [
+                'name' => 'analytics',
+                'label' => 'Analytical Cookies',
+                'description' => 'Analytical cookies help us to improve our website by collecting and reporting information on its usage.',
+                'cookies' => ['_ga', '_gid', '_gat', '__utma', '__utmt', '__utmb', '__utmc', '__utmz', '__utmv'],
+                'onAccept' => "analyticsWithConsent.gaAccept",
+                'onRevoke' => "analyticsWithConsent.gaRevoke"
+            ]
+        ];
+        if (get_field('gtm_marketing_consent', 'option')) {
+            $optionalCookies[] = [
+                'name' => 'marketing',
+                'label' => 'Marketing Cookies',
+                'description' => 'Marketing cookies help us to improve the relevency of advertising campaigns you receive from us.',
+                'cookies' => (explode(',', esc_js(get_field('gtm_marketing_cookies', 'option')))),
+                'onAccept' => "analyticsWithConsent.marketingAccept",
+                'onRevoke' => "analyticsWithConsent.marketingRevoke"
+            ];
+        }
         return apply_filters('awc_civic_cookie_control_config', [
             'apiKey' => get_field('civic_cookie_control_api_key', 'option'),
             'product' => get_field('civic_cookie_control_product_type', 'option'),
@@ -76,16 +96,7 @@ class Scripts implements \Dxw\Iguana\Registerable
             'theme' => 'DARK',
             'subDomains' => false,
             'toggleType' => 'checkbox',
-            'optionalCookies' => [
-                [
-                    'name' => 'analytics',
-                    'label' => 'Analytical Cookies',
-                    'description' => 'Analytical cookies help us to improve our website by collecting and reporting information on its usage.',
-                    'cookies' => ['_ga', '_gid', '_gat', '__utma', '__utmt', '__utmb', '__utmc', '__utmz', '__utmv'],
-                    'onAccept' => "analyticsWithConsent.gaAccept",
-                    'onRevoke' => "analyticsWithConsent.gaRevoke"
-                ]
-            ]
+            'optionalCookies' => $optionalCookies
         ]);
     }
 }

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -9,6 +9,7 @@ class Scripts implements \Dxw\Iguana\Registerable
         add_action('wp_enqueue_scripts', [$this, 'enqueueScripts']);
         add_action('wp_enqueue_scripts', [$this, 'enqueueStyles']);
         add_action('wp_head', [$this, 'addGA4']);
+        add_action('wp_head', [$this, 'addGTM']);
     }
 
     public function enqueueScripts() : void
@@ -43,6 +44,16 @@ class Scripts implements \Dxw\Iguana\Registerable
         $ga4Id = get_field('ga_4_id', 'option');
         if ($apiKey && $productType && $ga4Id) {
             printf('<script async id="awc_gtag" src="https://www.googletagmanager.com/gtag/js?id=%s"></script>', esc_attr($ga4Id));
+        }
+    }
+
+    public function addGTM() : void
+    {
+        $apiKey = get_field('civic_cookie_control_api_key', 'option');
+        $productType = get_field('civic_cookie_control_product_type', 'option');
+        $gtmId = get_field('google_analytics_gtm', 'option');
+        if ($apiKey && $productType && $gtmId) {
+            printf("<script>window.dataLayer = window.dataLayer || []; (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','%s')</script>", esc_js($gtmId));
         }
     }
 


### PR DESCRIPTION
This PR introduces a new feature where, if an admin has chosen to use Google Tag Manager, and opted into allowing analytics with consent to control marketing scripts, a user can opt in or out of marketing cookies, as well as analytics cookies. The plugin does this by managing the `ad_storage` and `analytics_storage` consent states that GTM has. It relies on the admin having set up their scripts correctly in GTM so they respect those two consent states. (This should happen automatically for Google Analytics added via GTM, but would require manual config in GTM for e.g. social media tracking. There's some instructions here for how this would be configured at the GTM end: https://support.cookiebot.com/hc/en-us/articles/360003793854-Google-Tag-Manager-deployment), but that doesn't need to be done in order to test this PR.

## How to test

It's difficult to test this 100%, as it relies on a Google Tag Manager account existing and being configured appropriately. However, we can test that the plugin is updating the consent state as expected, using the steps below:

### In the admin

1. Activate the plugin.
2. In the plugin settings (under Settings > Analytics with Consent), provide an Civic API key that can be used on localhost - you can find this in 1password under "Civic Cookie Notifier (localhost)"
3. Provide a valid GTM ID (you can use the one from Share Your Skills staging: https://web.staging.dfe-fh.dalmatian.dxw.net/wp-admin/options-general.php?page=analytics-with-consent)
4. Tick the "Include GTM marketing consent?" checkbox
5. Add a list of dummy cookies in the "GTM Marketing Cookies" box (e.g. `'cookie_1','cookie_2','cookie_3'`).
6. Save the settings

### In the front-end

1. The Cookie Control panel should open if you haven't already set any cookie preferences (or be closed if you have, with the icon in the bottom left)
2. It should show both "Analytical Cookies" and "Marketing Cookies" checkbox options
3. Open the web developer console. Under the "Sources" tab, locate `localhost/wp-content/plugins/analytics-with-consent/assets/js/analytics.js` (it will probably have a WP version query string on the end). Place breakpoints on lines 56 & 61.
4. When you check/uncheck the "Marketing Cookies" box, you should see those breakpoints being hit, showing the `ad_storage` consent status being set to either "granted" or "denied", depending on the status of the checkbox.
5. If you enter `cookieControlConfig.optionalCookies[1].cookies` into the console, it should return an array containing the values you entered under step 5 in the back-end. These are the cookies that Civic Cookie Control would attempt to remove when a user opts out of marketing cookies.