### PR TITLE
Deny consent for all consent types by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2024-03-06
+
+### Changed
+
+- All consent types are denied by default
+
 ## [1.4.0] - 2022-11-03
 
 ### Changed

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -67,7 +67,12 @@ var gtag = function () { dataLayer.push(arguments) }
 window.dataLayer = window.dataLayer || []
 gtag('consent', 'default', {
   'ad_storage': 'denied',
-  'analytics_storage': 'denied'
+  'analytics_storage': 'denied',
+  'ad_user_data': 'denied',
+  'ad_personalization': 'denied',
+  'functionality_storage': 'denied',
+  'personalization_storage': 'denied',
+  'security_storage': 'denied'
 })
 /* eslint-enable */
 if (cookieControlDefaultAnalytics.ga4Id !== '') {

--- a/index.php
+++ b/index.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://github.com/dxw/analytics-with-consent
  * Description: Google Analytics + CIVIC Cookie Control
  * Author: dxw
- * Version: 1.4.0
+ * Version: 1.5.0
  * Network: True
  */
 


### PR DESCRIPTION
This commit denies consent for all types of cookies, not just the types we expect to appear on client sits.

See:
    https://developers.google.com/tag-platform/security/concepts/consent-mode#consent-types