### PR TITLE
Chore/fix readme

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+## Description of changes
+...
+
+## Checklist
+- [ ] Changelog updated
+- [ ] If new release: major version tag to be bumped after release (see [docs](../README.md#changelog-and-versioning))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- PR template
+
 ## [1.5.2] - 2024-07-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ As well as the individual version tags, we also have a major version tag (curren
 
 (e.g. if you'd just published v1.6.0):
 
+```sh
 git checkout main
 git fetch --tags -f
 git tag -f v1 v1.6.0
 git push origin -f --tags
+```


### PR DESCRIPTION
This PR:

- Adds a PR template to remind people to update the major version tag after creating a new release (we should probably automate this eventually)
- Fixes the formatting of the git instructions in the README