### PR TITLE
Add settings link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Settings link appears in plugins page
+
 ## [1.5.3] - 2024-11-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.5.4] - 2024-11-28
 
 ### Added
 

--- a/index.php
+++ b/index.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://github.com/dxw/analytics-with-consent
  * Description: Google Analytics + CIVIC Cookie Control
  * Author: dxw
- * Version: 1.5.1
+ * Version: 1.5.4
  * Network: True
  */
 

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -19,7 +19,20 @@ describe(Scripts::class, function () {
 			expect('add_action')->toBeCalled()->with('wp_enqueue_scripts', [$this->scripts, 'enqueueStyles']);
 			expect('add_action')->toBeCalled()->with('wp_head', [$this->scripts, 'addGA4']);
 			expect('add_action')->toBeCalled()->with('wp_head', [$this->scripts, 'addGTM']);
+			allow('add_filter')->toBeCalled();
+			expect('add_filter')->toBeCalled()->with('plugin_action_links_analytics-with-consent/index.php', [$this->scripts, 'addActionLinks']);
+
 			$this->scripts->register();
+		});
+	});
+	describe('->addActionLinks()', function () {
+		it('adds a link to the settings page', function () {
+			allow('admin_url')->toBeCalled()->with('options-general.php?page=analytics-with-consent')->andReturn('https://example.com/wp-admin/options-general.php?page=analytics-with-consent');
+
+			$expected = ['<a href="https://example.com/wp-admin/options-general.php?page=analytics-with-consent">Settings</a>'];
+			$result = $this->scripts->addActionLinks([]);
+
+			expect($result)->toEqual($expected);
 		});
 	});
 

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -10,6 +10,14 @@ class Scripts implements \Dxw\Iguana\Registerable
 		add_action('wp_enqueue_scripts', [$this, 'enqueueStyles']);
 		add_action('wp_head', [$this, 'addGA4']);
 		add_action('wp_head', [$this, 'addGTM']);
+		add_filter('plugin_action_links_analytics-with-consent/index.php', [$this, 'addActionLinks']);
+	}
+
+	public function addActionLinks(array $links): array
+	{
+		$settingsLink = '<a href="' . admin_url('options-general.php?page=analytics-with-consent') . '">Settings</a>';
+		array_push($links, $settingsLink);
+		return $links;
 	}
 
 	public function enqueueScripts(): void


### PR DESCRIPTION
## Description of changes

Ensure plugin pages have link to settings page

## Screenshot

![Screenshot 2024-11-28 at 09 24 14](https://github.com/user-attachments/assets/05e924a9-0dc4-4609-89ca-e7a499263c4f)

## Testing

1. Add plugin to a site you are running locally
2. Switch to this branch
3. Open http://localhost/wp-admin/plugins.php
4. Check the settings link appears as in screenshot
5. Check the link goes to the correct page

## Checklist
- [x] Changelog updated
- [ ] If new release: major version tag to be bumped after release (see [docs](../README.md#changelog-and-versioning))
