### PR TITLE
Feature / add media embed cookie category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Uneleased
+
+### Added
+
+- Optional media embed cookie category
+
 ## [1.5.6] - 2025-06-26
 
 ### Fixed

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -75,6 +75,12 @@ var analyticsWithConsent = {
     gtag('consent', 'update', {
       'ad_storage' : 'denied'
     });
+  },
+  thirdPartyMediaEmbedAccept: function () {
+	console.log('Third party media embed cookies accepted');
+  },
+  thirdPartyMediaEmbedRevoke: function () {
+	console.log('Third party media embed cookies revoked');
   }
 }
 var gtag = function () { dataLayer.push(arguments) }

--- a/src/Options.php
+++ b/src/Options.php
@@ -156,6 +156,20 @@ class Options implements \Dxw\Iguana\Registerable
 					'append' => '',
 				],
 				[
+					'key' => 'field_third_party_media_embed_consent',
+					'label' => 'Include third party media embed consent?',
+					'name' => 'third_party_media_embed_consent',
+					'type' => 'true_false',
+					'instructions' => 'If you tick this, then the plugin will replace third party embeds with a placeholder until the user consents to embed cookies.',
+					'required' => 0,
+					'wrapper' => [
+						'width' => '',
+						'class' => '',
+						'id' => '',
+					],
+					'default_value' => ''
+				],
+				[
 					'key' => 'field_5f986ace6a81a',
 					'label' => 'CIVIC Cookie Control API key',
 					'name' => 'civic_cookie_control_api_key',

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -109,7 +109,7 @@ class Scripts implements \Dxw\Iguana\Registerable
 			$optionalCookies[] = [
 				'name' => 'third_party_media_embed',
 				'label' => 'Third Party Media Embed Cookies',
-				'description' => 'Third party media embed cookies help us to improve your experience on our website by remembering your preferences and tailoring content to you.',
+				'description' => 'Some pages of this site include media content hosted on third-party platforms like YouTube. If you enable this setting, this may result in those platforms collecting information about your viewing for analytics and advertising purposes. If you don’t enable this setting, that media content will not be displayed.',
 				'cookies' => ['third_party_media_embed'],
 				'onAccept' => "analyticsWithConsent.thirdPartyMediaEmbedAccept",
 				'onRevoke' => "analyticsWithConsent.thirdPartyMediaEmbedRevoke"

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -105,6 +105,16 @@ class Scripts implements \Dxw\Iguana\Registerable
 				'onRevoke' => "analyticsWithConsent.marketingRevoke"
 			];
 		}
+		if (get_field('third_party_media_embed_consent', 'option')) {
+			$optionalCookies[] = [
+				'name' => 'third_party_media_embed',
+				'label' => 'Third Party Media Embed Cookies',
+				'description' => 'Third party media embed cookies help us to improve your experience on our website by remembering your preferences and tailoring content to you.',
+				'cookies' => ['third_party_media_embed'],
+				'onAccept' => "analyticsWithConsent.thirdPartyMediaEmbedAccept",
+				'onRevoke' => "analyticsWithConsent.thirdPartyMediaEmbedRevoke"
+				];
+		}
 		return apply_filters('awc_civic_cookie_control_config', [
 			'apiKey' => trim(get_field('civic_cookie_control_api_key', 'option') ?? ''),
 			'product' => trim(get_field('civic_cookie_control_product_type', 'option') ?? ''),


### PR DESCRIPTION
## Description of changes
Adds a bew ACF true\false option for third-party media embed consent, which conditionally adds a new optional cookie category to the Civic config.
This is the first stage of work to get this funcitonality working see: https://trello.com/c/smNk2IUG/360-block-3rd-party-media-embeds-until-users-consent-to-3rd-party-media-cookies. Currently accepting or rejecting the cookie only fires a console log

To test locally: visit your local site as non-admin and once the Civic popup appears, check that there is a new media embed checkbox. Checking the box should log a message in the console, as should unchecking it again.

## Checklist
- [x] Changelog updated
- [ ] If new release: major version tag to be bumped after release (see [docs](../README.md#changelog-and-versioning))
