### PR TITLE
Feature/hide embed content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -9,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Optional media embed cookie category
+- Media embeds hidden by default if media embed cookie category active
 
 ## [1.5.6] - 2025-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Uneleased
 
@@ -69,7 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `wp-postpass_*` cookies (used to access WordPress password-protected pages) are marked as necessary
+- `wp-postpass_*` cookies (used to access WordPress password-protected pages)
+  are marked as necessary
 
 ## [1.3.0] - 2022-10-11
 
@@ -95,26 +97,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `awc_civic_cookie_control_config` filter, to allow default config to be added to or over-ridden
+- `awc_civic_cookie_control_config` filter, to allow default config to be added
+  to or over-ridden
 
 ## [0.2.2] - 2021-04-12
 
 ### Added
 
-- Fix to remove `rem` font size on headings - some sites the headings were inheriting a much smaller size
+- Fix to remove `rem` font size on headings - some sites the headings were
+  inheriting a much smaller size
 - Fix to overlapping header over pixel-based size custom appearance checkbox
 
 ## [0.2.1] - 2021-03-03
 
 ### Added
 
-- Fix to address reflow issues at 400% zoom level using improved layout styling to fill the page width and a more compact checkbox instead of slider control
+- Fix to address reflow issues at 400% zoom level using improved layout styling
+  to fill the page width and a more compact checkbox instead of slider control
 
 ## [0.2.0] - 2021-02-26
 
 ## Added
 
-- Accessible default styles for focus states on buttons & links in the cookie panel
+- Accessible default styles for focus states on buttons & links in the cookie
+  panel
 
 ## [0.1.0] - 2020-11-13
 

--- a/spec/embeds.spec.php
+++ b/spec/embeds.spec.php
@@ -53,7 +53,7 @@ describe(Embeds::class, function () {
 
 				$result = $this->embeds->embedPlaceholder('<iframe>embed</iframe>', 'https://example.com/video', [], 123);
 
-				expect($result)->toEqual('<div class="awc-embed-placeholder">Third party media content is blocked to comply with your cookie consent choices. Please enable third party media embed cookies to view this content</div>');
+				expect($result)->toEqual('<div class="awc-embed-placeholder" data-embed="PGlmcmFtZT5lbWJlZDwvaWZyYW1lPg==">Third party media content is blocked to comply with your cookie consent choices. Please enable third party media embed cookies to view this content</div>');
 			});
 		});
 	});

--- a/spec/embeds.spec.php
+++ b/spec/embeds.spec.php
@@ -52,8 +52,19 @@ describe(Embeds::class, function () {
 					allow('function_exists')->toBeCalled()->andReturn(true);
 					allow('get_field')->toBeCalled()->andReturn(true);
 					allow('is_admin')->toBeCalled()->andReturn(false);
+					expect('esc_url')->not->toBeCalled();
 
 					expect($this->embeds->filterBlock('<iframe>embed</iframe>', ['blockName' => 'core/embed']))->toContain('awc-embed-placeholder');
+				});
+				it('includes the media URL in the placeholder if provided', function () {
+					allow('function_exists')->toBeCalled()->andReturn(true);
+					allow('get_field')->toBeCalled()->andReturn(true);
+					allow('is_admin')->toBeCalled()->andReturn(false);
+					allow('esc_url')->toBeCalled()->andRun(function ($input) {
+						return '_' . $input . '_';
+					});
+
+					expect($this->embeds->filterBlock('<iframe>embed</iframe>', ['blockName' => 'core/embed', 'attrs' => ['url' => 'http://bbc.co.uk']]))->toContain('_http://bbc.co.uk_');
 				});
 			});
 		});
@@ -99,10 +110,14 @@ describe(Embeds::class, function () {
 				allow('function_exists')->toBeCalled()->andReturn(true);
 				allow('get_field')->toBeCalled()->with('third_party_media_embed_consent', 'option')->andReturn(true);
 				allow('is_admin')->toBeCalled()->andReturn(false);
+				allow('esc_url')->toBeCalled()->andRun(function ($input) {
+					return '_' . $input . '_';
+				});
 
 				$result = $this->embeds->embedPlaceholder('<iframe>embed</iframe>', 'https://example.com/video', [], 123);
 
-				expect($result)->toEqual('<div class="awc-embed-placeholder" data-embed="PGlmcmFtZT5lbWJlZDwvaWZyYW1lPg==">Third party media content is blocked to comply with your cookie consent choices. Please enable third party media embed cookies to view this content</div>');
+				expect($result)->toContain('class="awc-embed-placeholder"');
+				expect($result)->toContain('_https://example.com/video_');
 			});
 		});
 	});

--- a/spec/embeds.spec.php
+++ b/spec/embeds.spec.php
@@ -25,7 +25,6 @@ describe(Embeds::class, function () {
 			it('returns the original embed html', function () {
 				allow('function_exists')->toBeCalled()->andReturn(true);
 				allow('get_field')->toBeCalled()->with('third_party_media_embed_consent', 'option')->andReturn(false);
-				allow('current_user_can')->toBeCalled()->andReturn(false);
 
 				$result = $this->embeds->embedPlaceholder('<iframe>embed</iframe>', 'https://example.com/video', [], 123);
 
@@ -33,11 +32,11 @@ describe(Embeds::class, function () {
 			});
 		});
 
-		context('current user can edit posts', function () {
+		context('inside admin interface', function () {
 			it('returns the original embed html', function () {
 				allow('function_exists')->toBeCalled()->andReturn(true);
 				allow('get_field')->toBeCalled()->with('third_party_media_embed_consent', 'option')->andReturn(true);
-				allow('current_user_can')->toBeCalled()->with('edit_posts')->andReturn(true);
+				allow('is_admin')->toBeCalled()->andReturn(true);
 
 				$result = $this->embeds->embedPlaceholder('<iframe>embed</iframe>', 'https://example.com/video', [], 123);
 
@@ -45,11 +44,11 @@ describe(Embeds::class, function () {
 			});
 		});
 
-		context('third party embed consent setting is enabled and user cannot edit posts', function () {
+		context('third party embed consent setting is enabled and not within the admin panel', function () {
 			it('returns the placeholder html', function () {
 				allow('function_exists')->toBeCalled()->andReturn(true);
 				allow('get_field')->toBeCalled()->with('third_party_media_embed_consent', 'option')->andReturn(true);
-				allow('current_user_can')->toBeCalled()->with('edit_posts')->andReturn(false);
+				allow('is_admin')->toBeCalled()->andReturn(false);
 
 				$result = $this->embeds->embedPlaceholder('<iframe>embed</iframe>', 'https://example.com/video', [], 123);
 

--- a/spec/embeds.spec.php
+++ b/spec/embeds.spec.php
@@ -15,8 +15,47 @@ describe(Embeds::class, function () {
 		it('adds the embed filter', function () {
 			allow('add_filter')->toBeCalled();
 			expect('add_filter')->toBeCalled()->once()->with('embed_oembed_html', [$this->embeds, 'embedPlaceholder'], 10, 4);
+			expect('add_filter')->toBeCalled()->once()->with('render_block', [$this->embeds, 'filterBlock']);
 
 			$this->embeds->register();
+		});
+	});
+
+	describe('->filterBlock()', function () {
+		context('ACF is disabled', function () {
+			it('returns the block content', function () {
+				allow('function_exists')->toBeCalled()->andReturn(false);
+
+				expect($this->embeds->filterBlock('<iframe>embed</iframe>', ['blockName' => 'core/embed']))->toEqual('<iframe>embed</iframe>');
+			});
+		});
+		context('third party media consent is disabled', function () {
+			it('returns the block content', function () {
+				allow('function_exists')->toBeCalled()->andReturn(true);
+				allow('get_field')->toBeCalled()->andReturn(false);
+
+				expect($this->embeds->filterBlock('<iframe>embed</iframe>', ['blockName' => 'core/embed']))->toEqual('<iframe>embed</iframe>');
+			});
+		});
+		context('third party media consent is enabled', function () {
+			context('but we are in the admin panel', function () {
+				it('returns the block content', function () {
+					allow('function_exists')->toBeCalled()->andReturn(true);
+					allow('get_field')->toBeCalled()->andReturn(true);
+					allow('is_admin')->toBeCalled()->andReturn(true);
+
+					expect($this->embeds->filterBlock('<iframe>embed</iframe>', ['blockName' => 'core/embed']))->toEqual('<iframe>embed</iframe>');
+				});
+			});
+			context('and we are in the front end', function () {
+				it('returns the placeholder', function () {
+					allow('function_exists')->toBeCalled()->andReturn(true);
+					allow('get_field')->toBeCalled()->andReturn(true);
+					allow('is_admin')->toBeCalled()->andReturn(false);
+
+					expect($this->embeds->filterBlock('<iframe>embed</iframe>', ['blockName' => 'core/embed']))->toContain('awc-embed-placeholder');
+				});
+			});
 		});
 	});
 
@@ -45,6 +84,17 @@ describe(Embeds::class, function () {
 		});
 
 		context('third party embed consent setting is enabled and not within the admin panel', function () {
+			context('but the placeholder is already in place', function () {
+				it('returns the input', function () {
+					allow('function_exists')->toBeCalled()->andReturn(true);
+					allow('get_field')->toBeCalled()->with('third_party_media_embed_consent', 'option')->andReturn(true);
+					allow('is_admin')->toBeCalled()->andReturn(false);
+
+					$result = $this->embeds->embedPlaceholder('<div class="awc-embed-placeholder">Hello</div>', 'https://example.com/video', [], 123);
+
+					expect($result)->toEqual('<div class="awc-embed-placeholder">Hello</div>');
+				});
+			});
 			it('returns the placeholder html', function () {
 				allow('function_exists')->toBeCalled()->andReturn(true);
 				allow('get_field')->toBeCalled()->with('third_party_media_embed_consent', 'option')->andReturn(true);

--- a/spec/embeds.spec.php
+++ b/spec/embeds.spec.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace AnalyticsWithConsent;
+
+describe(Embeds::class, function () {
+	beforeEach(function () {
+		$this->embeds = new Embeds();
+	});
+
+	it('is registerable', function () {
+		expect($this->embeds)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
+	});
+
+	describe('->register()', function () {
+		it('adds the embed filter', function () {
+			allow('add_filter')->toBeCalled();
+			expect('add_filter')->toBeCalled()->once()->with('embed_oembed_html', [$this->embeds, 'embedPlaceholder'], 10, 4);
+
+			$this->embeds->register();
+		});
+	});
+
+	describe('->embedPlaceholder()', function () {
+		context('third party embed consent setting is disabled', function () {
+			it('returns the original embed html', function () {
+				allow('function_exists')->toBeCalled()->andReturn(true);
+				allow('get_field')->toBeCalled()->with('third_party_media_embed_consent', 'option')->andReturn(false);
+				allow('current_user_can')->toBeCalled()->andReturn(false);
+
+				$result = $this->embeds->embedPlaceholder('<iframe>embed</iframe>', 'https://example.com/video', [], 123);
+
+				expect($result)->toEqual('<iframe>embed</iframe>');
+			});
+		});
+
+		context('current user can edit posts', function () {
+			it('returns the original embed html', function () {
+				allow('function_exists')->toBeCalled()->andReturn(true);
+				allow('get_field')->toBeCalled()->with('third_party_media_embed_consent', 'option')->andReturn(true);
+				allow('current_user_can')->toBeCalled()->with('edit_posts')->andReturn(true);
+
+				$result = $this->embeds->embedPlaceholder('<iframe>embed</iframe>', 'https://example.com/video', [], 123);
+
+				expect($result)->toEqual('<iframe>embed</iframe>');
+			});
+		});
+
+		context('third party embed consent setting is enabled and user cannot edit posts', function () {
+			it('returns the placeholder html', function () {
+				allow('function_exists')->toBeCalled()->andReturn(true);
+				allow('get_field')->toBeCalled()->with('third_party_media_embed_consent', 'option')->andReturn(true);
+				allow('current_user_can')->toBeCalled()->with('edit_posts')->andReturn(false);
+
+				$result = $this->embeds->embedPlaceholder('<iframe>embed</iframe>', 'https://example.com/video', [], 123);
+
+				expect($result)->toEqual('<div class="awc-embed-placeholder">Third party media content is blocked to comply with your cookie consent choices. Please enable third party media embed cookies to view this content</div>');
+			});
+		});
+	});
+});

--- a/src/Embeds.php
+++ b/src/Embeds.php
@@ -14,7 +14,7 @@ class Embeds implements \Dxw\Iguana\Registerable
 		if (!$this->isThirdPartyMediaEmbedConsentEnabled() || current_user_can('edit_posts')) {
 			return $html;
 		}
-		return $this->placeholderMarkup();
+		return $this->placeholderMarkup($html);
 	}
 
 	private function isThirdPartyMediaEmbedConsentEnabled(): bool
@@ -26,8 +26,9 @@ class Embeds implements \Dxw\Iguana\Registerable
 		return get_field('third_party_media_embed_consent', 'option') === true;
 	}
 
-	private function placeholderMarkup(): string
+	private function placeholderMarkup(string $html): string
 	{
-		return '<div class="awc-embed-placeholder">Third party media content is blocked to comply with your cookie consent choices. Please enable third party media embed cookies to view this content</div>';
+		$encodedHtml = base64_encode($html);
+		return '<div class="awc-embed-placeholder" data-embed="' . $encodedHtml . '">Third party media content is blocked to comply with your cookie consent choices. Please enable third party media embed cookies to view this content</div>';
 	}
 }

--- a/src/Embeds.php
+++ b/src/Embeds.php
@@ -25,7 +25,7 @@ class Embeds implements \Dxw\Iguana\Registerable
 		return $blockContent;
 	}
 
-	public function embedPlaceholder(string $html, string $url, array $attr, int $post_ID): string
+	public function embedPlaceholder(string $html, string $url): string
 	{
 		if (!$this->isThirdPartyMediaEmbedConsentEnabled() || is_admin()) {
 			return $html;

--- a/src/Embeds.php
+++ b/src/Embeds.php
@@ -12,7 +12,7 @@ class Embeds implements \Dxw\Iguana\Registerable
 
 	public function filterBlock(string $blockContent, array $block): string
 	{
-		if (!$this->isThirdPartyMediaEmbedConsentEnabled() || is_admin()) {
+		if ($this->disablePlaceholder()) {
 			return $blockContent;
 		}
 		if (strpos($block['blockName'], 'core-embed/') === 0 || $block['blockName'] === 'core/embed') {
@@ -27,13 +27,18 @@ class Embeds implements \Dxw\Iguana\Registerable
 
 	public function embedPlaceholder(string $html, string $url): string
 	{
-		if (!$this->isThirdPartyMediaEmbedConsentEnabled() || is_admin()) {
+		if ($this->disablePlaceholder()) {
 			return $html;
 		}
 		if (str_contains($html, 'awc-embed-placeholder')) {
 			return $html;
 		}
 		return $this->placeholderMarkup($html, $url);
+	}
+
+	private function disablePlaceholder(): bool
+	{
+		return(!$this->isThirdPartyMediaEmbedConsentEnabled() || is_admin());
 	}
 
 	private function isThirdPartyMediaEmbedConsentEnabled(): bool

--- a/src/Embeds.php
+++ b/src/Embeds.php
@@ -11,7 +11,7 @@ class Embeds implements \Dxw\Iguana\Registerable
 
 	public function embedPlaceholder(string $html, string $url, array $attr, int $post_ID): string
 	{
-		if (!$this->isThirdPartyMediaEmbedConsentEnabled() || current_user_can('edit_posts')) {
+		if (!$this->isThirdPartyMediaEmbedConsentEnabled() || is_admin()) {
 			return $html;
 		}
 		return $this->placeholderMarkup($html);

--- a/src/Embeds.php
+++ b/src/Embeds.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace AnalyticsWithConsent;
+
+class Embeds implements \Dxw\Iguana\Registerable
+{
+	public function register(): void
+	{
+		add_filter('embed_oembed_html', [$this, 'embedPlaceholder'], 10, 4);
+	}
+
+	public function embedPlaceholder(string $html, string $url, array $attr, int $post_ID): string
+	{
+		if (!$this->isThirdPartyMediaEmbedConsentEnabled() || current_user_can('edit_posts')) {
+			return $html;
+		}
+		return $this->placeholderMarkup();
+	}
+
+	private function isThirdPartyMediaEmbedConsentEnabled(): bool
+	{
+		if (!function_exists('get_field')) {
+			return false;
+		}
+
+		return get_field('third_party_media_embed_consent', 'option') === true;
+	}
+
+	private function placeholderMarkup(): string
+	{
+		return '<div class="awc-embed-placeholder">Third party media content is blocked to comply with your cookie consent choices. Please enable third party media embed cookies to view this content</div>';
+	}
+}

--- a/src/Embeds.php
+++ b/src/Embeds.php
@@ -7,11 +7,26 @@ class Embeds implements \Dxw\Iguana\Registerable
 	public function register(): void
 	{
 		add_filter('embed_oembed_html', [$this, 'embedPlaceholder'], 10, 4);
+		add_filter('render_block', [$this, 'filterBlock'], 10, 2);
+	}
+
+	public function filterBlock(string $blockContent, array $block): string
+	{
+		if (!$this->isThirdPartyMediaEmbedConsentEnabled() || is_admin()) {
+			return $blockContent;
+		}
+		if (strpos($block['blockName'], 'core-embed/') === 0 || $block['blockName'] === 'core/embed') {
+			return $this->placeholderMarkup($blockContent);
+		}
+		return $blockContent;
 	}
 
 	public function embedPlaceholder(string $html, string $url, array $attr, int $post_ID): string
 	{
 		if (!$this->isThirdPartyMediaEmbedConsentEnabled() || is_admin()) {
+			return $html;
+		}
+		if (str_contains($html, 'awc-embed-placeholder')) {
 			return $html;
 		}
 		return $this->placeholderMarkup($html);

--- a/src/Embeds.php
+++ b/src/Embeds.php
@@ -16,7 +16,11 @@ class Embeds implements \Dxw\Iguana\Registerable
 			return $blockContent;
 		}
 		if (strpos($block['blockName'], 'core-embed/') === 0 || $block['blockName'] === 'core/embed') {
-			return $this->placeholderMarkup($blockContent);
+			$url = '';
+			if (array_key_exists('attrs', $block) && array_key_exists('url', $block['attrs'])) {
+				$url = $block['attrs']['url'];
+			}
+			return $this->placeholderMarkup($blockContent, $url);
 		}
 		return $blockContent;
 	}
@@ -29,7 +33,7 @@ class Embeds implements \Dxw\Iguana\Registerable
 		if (str_contains($html, 'awc-embed-placeholder')) {
 			return $html;
 		}
-		return $this->placeholderMarkup($html);
+		return $this->placeholderMarkup($html, $url);
 	}
 
 	private function isThirdPartyMediaEmbedConsentEnabled(): bool
@@ -41,9 +45,13 @@ class Embeds implements \Dxw\Iguana\Registerable
 		return get_field('third_party_media_embed_consent', 'option') === true;
 	}
 
-	private function placeholderMarkup(string $html): string
+	private function placeholderMarkup(string $html, string $url): string
 	{
 		$encodedHtml = base64_encode($html);
-		return '<div class="awc-embed-placeholder" data-embed="' . $encodedHtml . '">Third party media content is blocked to comply with your cookie consent choices. Please enable third party media embed cookies to view this content</div>';
+		$output = '<div class="awc-embed-placeholder" data-embed="' . $encodedHtml . '"><p>Third party media content is blocked to comply with your cookie consent choices. Please enable third party media embed cookies to view this content.</p>';
+		if (!empty($url)) {
+			$output .= '<p>You can view the content on the external site here: <a href="' . esc_url($url) . '">' . esc_url($url) . '</a></p>';
+		}
+		return $output . '</div>';
 	}
 }

--- a/src/di.php
+++ b/src/di.php
@@ -1,4 +1,5 @@
 <?php
 
+$registrar->addInstance(new \AnalyticsWithConsent\Embeds());
 $registrar->addInstance(new \AnalyticsWithConsent\Options());
 $registrar->addInstance(new \AnalyticsWithConsent\Scripts());


### PR DESCRIPTION
This PR adds automatic blocking of embed blocks if the "Third party media embed consent" option is ticked in the admin analytics with consent settings (indicating that users should have to explicitly opt into these cookies). 

The embed is replaced with placeholder text, and a link to the embed content on the original third-party site.

The ability for the user to reveal the embeds by opting into cookies will be added in a subsequent PR.

## How to test

1. Activate Analytics with Consent on your site, and checkout this branch
2. Confirm that on the Analytics with Consent settings page, "Include third party media embed consent?" is not checked
3. Add a page with some embed blocks
4. Confirm those embeds display as expected, in the editor and the front-end
5. Update the Analytics with Consent settings, so that "Include third party media embed consent?" is checked
6. Confirm that the embeds are now replaced in the front-end with placeholder text, and a link to the embedded content
7. Confirm that the embeds still display in the editor
8. Install and activate the classic editor plugin, and add embeds in the classic editor
9. Confirm those also are replaced with a placeholder in the front-end

## Checklist
- [x] Changelog updated
- [ ] If new release: major version tag to be bumped after release (see [docs](../README.md#changelog-and-versioning))
