### PR TITLE
Feature/embed cookie consent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to
 
 ### Added
 
-- Optional media embed cookie category
-- Media embeds hidden by default if media embed cookie category active
+- Full opt-in/out for third party media embeds (disabled by default, controlled
+  by toggle in settings)
 - ESLint with JS standard style
 
 ### Removed

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -42,8 +42,8 @@ var analyticsWithConsent = {
         r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
         a.appendChild(r);
       })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-	  }
-	  // Hotjar
+    }
+    // Hotjar
   },
   gaRevoke: function () {
     // Disable Google Analytics (UA)

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -80,9 +80,13 @@ var analyticsWithConsent = {
     if (typeof window.hydrateAllEmbeds === 'function') {
       window.hydrateAllEmbeds();
     }
+    console.log('Third party media embed cookies accepted');
   },
   thirdPartyMediaEmbedRevoke: function () {
-    window.location.reload();
+    if (typeof window.dehydrateAllEmbeds === 'function') {
+      window.dehydrateAllEmbeds();
+    }
+    console.log('Third party media embed cookies revoked');
   }
 }
 var gtag = function () { dataLayer.push(arguments) }
@@ -104,9 +108,36 @@ if (cookieControlDefaultAnalytics.ga4Id !== '') {
 window.hydrateAllEmbeds = function () {
   const placeholders = document.querySelectorAll('.awc-embed-placeholder')
   placeholders.forEach(el => {
+    const placeholderContent = el.querySelector('.awc-placeholder-content')
+    if (placeholderContent) {
+      placeholderContent.style.display = 'none'
+    }
+
+    let embedWrapper = el.querySelector('.awc-embed-wrapper')
+    if (!embedWrapper) {
+      embedWrapper = document.createElement('div')
+      embedWrapper.className = 'awc-embed-wrapper'
+      el.appendChild(embedWrapper)
+    }
+
     const encoded = el.getAttribute('data-embed')
     if (encoded) {
-      el.innerHTML = atob(encoded)
+      embedWrapper.innerHTML = atob(encoded)
+    }
+  })
+}
+
+window.dehydrateAllEmbeds = function () {
+  const placeholders = document.querySelectorAll('.awc-embed-placeholder')
+  placeholders.forEach(el => {
+    const embedWrapper = el.querySelector('.awc-embed-wrapper')
+    if (embedWrapper) {
+      embedWrapper.remove()
+    }
+
+    const placeholderContent = el.querySelector('.awc-placeholder-content')
+    if (placeholderContent) {
+      placeholderContent.style.display = ''
     }
   })
 }

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -77,10 +77,12 @@ var analyticsWithConsent = {
     });
   },
   thirdPartyMediaEmbedAccept: function () {
-	console.log('Third party media embed cookies accepted');
+    if (typeof window.hydrateAllEmbeds === 'function') {
+      window.hydrateAllEmbeds();
+    }
   },
   thirdPartyMediaEmbedRevoke: function () {
-	console.log('Third party media embed cookies revoked');
+    window.location.reload();
   }
 }
 var gtag = function () { dataLayer.push(arguments) }
@@ -98,4 +100,13 @@ gtag('consent', 'default', {
 if (cookieControlDefaultAnalytics.ga4Id !== '') {
   gtag('js', new Date())
   gtag('config', cookieControlDefaultAnalytics.ga4Id)
+}
+window.hydrateAllEmbeds = function () {
+  const placeholders = document.querySelectorAll('.awc-embed-placeholder')
+  placeholders.forEach(el => {
+    const encoded = el.getAttribute('data-embed')
+    if (encoded) {
+      el.innerHTML = atob(encoded)
+    }
+  })
 }

--- a/spec/embeds.spec.php
+++ b/spec/embeds.spec.php
@@ -48,6 +48,16 @@ describe(Embeds::class, function () {
 				});
 			});
 			context('and we are in the front end', function () {
+				context('but the placeholder is already there', function () {
+					it('returns the existing html', function () {
+						allow('function_exists')->toBeCalled()->andReturn(true);
+						allow('get_field')->toBeCalled()->andReturn(true);
+						allow('is_admin')->toBeCalled()->andReturn(false);
+						expect('esc_url')->not->toBeCalled();
+
+						expect($this->embeds->filterBlock('<div class="awc-embed-placeholder">This is some text</div>', ['blockName' => 'core/embed']))->toEqual('<div class="awc-embed-placeholder">This is some text</div>');
+					});
+				});
 				it('returns the placeholder', function () {
 					allow('function_exists')->toBeCalled()->andReturn(true);
 					allow('get_field')->toBeCalled()->andReturn(true);

--- a/spec/embeds.spec.php
+++ b/spec/embeds.spec.php
@@ -64,7 +64,9 @@ describe(Embeds::class, function () {
 					allow('is_admin')->toBeCalled()->andReturn(false);
 					expect('esc_url')->not->toBeCalled();
 
-					expect($this->embeds->filterBlock('<iframe>embed</iframe>', ['blockName' => 'core/embed']))->toContain('awc-embed-placeholder');
+					$result = $this->embeds->filterBlock('<iframe>embed</iframe>', ['blockName' => 'core/embed']);
+					expect($result)->toContain('awc-embed-placeholder');
+					expect($result)->toContain('awc-placeholder-content');
 				});
 				it('includes the media URL in the placeholder if provided', function () {
 					allow('function_exists')->toBeCalled()->andReturn(true);
@@ -127,6 +129,7 @@ describe(Embeds::class, function () {
 				$result = $this->embeds->embedPlaceholder('<iframe>embed</iframe>', 'https://example.com/video', [], 123);
 
 				expect($result)->toContain('class="awc-embed-placeholder"');
+				expect($result)->toContain('class="awc-placeholder-content"');
 				expect($result)->toContain('_https://example.com/video_');
 			});
 		});

--- a/src/Embeds.php
+++ b/src/Embeds.php
@@ -15,6 +15,9 @@ class Embeds implements \Dxw\Iguana\Registerable
 		if ($this->disablePlaceholder()) {
 			return $blockContent;
 		}
+		if (str_contains($blockContent, 'awc-embed-placeholder')) {
+			return $blockContent;
+		}
 		if (strpos($block['blockName'], 'core-embed/') === 0 || $block['blockName'] === 'core/embed') {
 			$url = '';
 			if (array_key_exists('attrs', $block) && array_key_exists('url', $block['attrs'])) {

--- a/src/Embeds.php
+++ b/src/Embeds.php
@@ -56,10 +56,12 @@ class Embeds implements \Dxw\Iguana\Registerable
 	private function placeholderMarkup(string $html, string $url): string
 	{
 		$encodedHtml = base64_encode($html);
-		$output = '<div class="awc-embed-placeholder" data-embed="' . $encodedHtml . '"><p>Third party media content is blocked to comply with your cookie consent choices. Please enable third party media embed cookies to view this content.</p>';
+		$output = '<div class="awc-embed-placeholder" data-embed="' . $encodedHtml . '">';
+		$output .= '<div class="awc-placeholder-content"><p>Third party media content is blocked to comply with your cookie consent choices. Please enable third party media embed cookies to view this content.</p>';
 		if (!empty($url)) {
 			$output .= '<p>You can view the content on the external site here: <a href="' . esc_url($url) . '">' . esc_url($url) . '</a></p>';
 		}
-		return $output . '</div>';
+		$output .= '</div></div>';
+		return $output;
 	}
 }


### PR DESCRIPTION
This PR adds the ability for users to opt in or out of third-party media embed cookies, meaning that the embed HTML is only rendered if they opt in.

When a user is opted out, placeholder HTML is shown to them. The embed HTML is held as a base64-encoded attribute on that placeholder.

When they opt in, a piece of JS takes that attribute and turns it into HTML that is added to the page. The placeholder text is then hidden.

If they then opt out again, the embed HTML is completely removed from the page, and the placeholder text is again shown.

The placeholder is wrapped within its own div, so it can be styled if needed.

## How to test

1. Spin up a site that uses analytics with consent
2. Ensure that third party media embed consent is checked in the analytics with consent settings page
3. Create a page that contains a number of embed blocks
4. View the page in the front end
5. When you are opted out of embed cookies, the placeholder text, with link to the embed content, should be shown
6. When you opt in, the full embed should be shown
7. If you opt in, then back out again, examining the source of the page should show the embed HTML is completely removed, not just hidden
8. Whichever option you select and save in cookie consent should persist in next page load

## Checklist
- [x] Changelog updated
- [ ] If new release: major version tag to be bumped after release (see [docs](../README.md#changelog-and-versioning))
