### PR TITLE
Fix/check for value before passing as parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-06-05
+
+### Fixed
+
+- Check for value of 'blockName' before passing to strpos
+
 ## [1.6.0] - 2026-06-02
 
 ### Added

--- a/index.php
+++ b/index.php
@@ -13,7 +13,7 @@
  * Plugin URI: https://github.com/dxw/analytics-with-consent
  * Description: Google Analytics + CIVIC Cookie Control
  * Author: dxw
- * Version: 1.6.0
+ * Version: 1.6.1
  * Network: True
  */
 

--- a/src/Embeds.php
+++ b/src/Embeds.php
@@ -18,7 +18,7 @@ class Embeds implements \Dxw\Iguana\Registerable
 		if (str_contains($blockContent, 'awc-embed-placeholder')) {
 			return $blockContent;
 		}
-		if (strpos($block['blockName'], 'core-embed/') === 0 || $block['blockName'] === 'core/embed') {
+		if ($block['blockName'] && (strpos($block['blockName'], 'core-embed/') === 0 || $block['blockName'] === 'core/embed')) {
 			$url = '';
 			if (array_key_exists('attrs', $block) && array_key_exists('url', $block['attrs'])) {
 				$url = $block['attrs']['url'];


### PR DESCRIPTION
## Description of changes

Ensures that 'blockName' is set before passing it to strpos.

To test, go to any block editor page - it should return no errors. Video embed content should continue to work as previously
...

## Checklist
- [x] Changelog updated
- [x] If new release: major version tag to be bumped after release (see [docs](../README.md#changelog-and-versioning))
