### PR TITLE
Feature/add more info to embed message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - Check for value of 'blockName' before passing to strpos
 
+### Added
+
+- More information and cookie popup link to blocked embed message
+
 ## [1.6.0] - 2026-06-02
 
 ### Added

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -87,6 +87,11 @@ var analyticsWithConsent = {
       window.dehydrateAllEmbeds();
     }
     console.log('Third party media embed cookies revoked');
+  },
+  showCookiePopup: function () {
+    if (typeof CookieControl !== 'undefined' && typeof CookieControl.open === 'function') {
+      CookieControl.open()
+    }
   }
 }
 var gtag = function () { dataLayer.push(arguments) }

--- a/src/Embeds.php
+++ b/src/Embeds.php
@@ -58,6 +58,7 @@ class Embeds implements \Dxw\Iguana\Registerable
 		$encodedHtml = base64_encode($html);
 		$output = '<div class="awc-embed-placeholder" data-embed="' . $encodedHtml . '">';
 		$output .= '<div class="awc-placeholder-content"><p>Third party media content is blocked to comply with your cookie consent choices. Please enable third party media embed cookies to view this content.</p>';
+		$output .= '<p>To do this, <a href="#" onclick="analyticsWithConsent.showCookiePopup(); return false;">open the cookie control panel</a> and select the Third Party Media Embed Cookies option.</p>';
 		if (!empty($url)) {
 			$output .= '<p>You can view the content on the external site here: <a href="' . esc_url($url) . '">' . esc_url($url) . '</a></p>';
 		}


### PR DESCRIPTION
## Description of changes

Adds some more information to the blocked embed message, to hopefully make it easier for users to accept the embed cookie, if that's what they want to do.

To test - reject embed cookies and view a page with a video embed. Check the message makes sense and that when you click the link the popup is activated.
...

## Checklist
- [x] Changelog updated
- [ ] If new release: major version tag to be bumped after release (see [docs](../README.md#changelog-and-versioning))
