### PR TITLE
Release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## Unreleased
 
+## [1.7.0] - 2026-08-13
+
 ### Added
 
 - Allow themes and plugins to restrict Google Tag Manager's tag deployment, via a blocklist and/or an allowlist

--- a/index.php
+++ b/index.php
@@ -13,9 +13,9 @@
  * Plugin URI: https://github.com/dxw/analytics-with-consent
  * Description: Google Analytics + CIVIC Cookie Control
  * Author: dxw
- * Version: 1.6.1
+ * Version: 1.7.0
  * Network: True
  */
 
-$registrar = require __DIR__.'/src/load.php';
+$registrar = require __DIR__ . '/src/load.php';
 $registrar->register();


### PR DESCRIPTION
## Description of changes

### Added

- Allow themes and plugins to restrict Google Tag Manager's tag deployment, via a blocklist and/or an allowlist

### Changed

- Replace PHP print functions with WordPress functions

## Checklist
- [x] Changelog updated
- [x] If new release: major version tag to be bumped after release (see [docs](../README.md#changelog-and-versioning))
