### PR TITLE
Fix/fatal embed error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## Unreleased
 
+- Fix fatal error on video embed when post ID not available
+
 ## [1.7.0] - 2026-08-13
 
 ### Added

--- a/src/Embeds.php
+++ b/src/Embeds.php
@@ -28,7 +28,7 @@ class Embeds implements \Dxw\Iguana\Registerable
 		return $blockContent;
 	}
 
-	public function embedPlaceholder(string $html, string $url, array $attr, int $postId): string
+	public function embedPlaceholder(string $html, string $url, array $attr, int|null $postId): string
 	{
 		if ($this->disablePlaceholder()) {
 			return $html;


### PR DESCRIPTION
## Description of changes
Fix fatal error thrown when post ID is null
Although the post variable is not used, it was typeset to an integer.
However, it must fire sometimes before the post object is loaded and the ID returns null. To stop the fatal error a type option of null is added.

`2026/08/20 07:14:18 [error] 902#902: *74975 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught TypeError: AnalyticsWithConsent\Embeds::embedPlaceholder(): Argument #4 ($postId) must be of type int, null given, called in /var/www/html/wp-includes/class-wp-hook.php on line 341 and defined in /var/www/html/wp-content/plugins/analytics-with-consent/src/Embeds.php:31`

## Checklist
- [x] Changelog updated
- [ ] If new release: major version tag to be bumped after release (see [docs](../README.md#changelog-and-versioning))
